### PR TITLE
build: upgrade to use go1.19

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup Go environment
         uses: actions/setup-go@v2.1.3
         with:
-          go-version: 1.17
+          go-version: 1.19
       - name: Cache downloaded module
         uses: actions/cache@v2
         with:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/qjfoidnh/BaiduPCS-Go
 
-go 1.17
+go 1.19
 
 require (
 	github.com/GeertJohan/go.incremental v1.0.0
@@ -18,7 +18,7 @@ require (
 	github.com/tidwall/gjson v1.6.4
 	github.com/urfave/cli v1.22.5
 	golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550
-	golang.org/x/sys v0.0.0-20200615200032-f1bc736245b1
+	golang.org/x/sys v0.2.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -31,7 +31,6 @@ github.com/cloudflare/golz4 v0.0.0-20150217214814-ef862a3cdc58/go.mod h1:EOBUe0h
 github.com/couchbase/go-couchbase v0.0.0-20200519150804-63f3cdb75e0d/go.mod h1:TWI8EKQMs5u5jLKW/tsb9VwauIrMIxQG1r5fMsswK5U=
 github.com/couchbase/gomemcached v0.0.0-20200526233749-ec430f949808/go.mod h1:srVSlQLB8iXBVXHgnqemxUXqN6FCvClgCMPCsjBDR7c=
 github.com/couchbase/goutils v0.0.0-20180530154633-e865a1461c8a/go.mod h1:BQwMFlJzDjFDG3DJUdU0KORxn88UlsOULuxLExMh3Hs=
-github.com/cpuguy83/go-md2man v1.0.10 h1:BSKMNlYxDvnunlTymqtgONjNnaRV1sTpcovwwjF22jk=
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d h1:U+s90UTSYgptZMwQh2aRr3LuazLJIa+Pg3Kc1ylSYVY=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
@@ -159,7 +158,6 @@ github.com/qjfoidnh/Baidu-Login v1.4.0/go.mod h1:oRFCmVYQka0KYwvbf2zS6UeMupgv0w1
 github.com/qjfoidnh/BaiduPCS-Go v0.0.0-20201218134534-d55d9918bd1b/go.mod h1:00iH1dQEStMeT3t+oeVrIucWcu3fFEaFYyygNxfOEv4=
 github.com/qjfoidnh/baidu-tools v1.2.0 h1:VoXJCN16xzL0xh1BOI2l2p80X5HwKB0PE4SgtX8wn30=
 github.com/qjfoidnh/baidu-tools v1.2.0/go.mod h1:TzIKHinLPcQbWxAROpqoSvYxM/kDeswfXJaQ2E1p4zs=
-github.com/russross/blackfriday v1.5.2 h1:HyvC0ARfnZBqnXwABFeSZHpKvJHJJfPz81GNueLj0oo=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/russross/blackfriday/v2 v2.0.1 h1:lPqVAte+HuHNfhJ/0LC98ESWRz8afy9tM/0RK8m9o+Q=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
@@ -225,6 +223,8 @@ golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200615200032-f1bc736245b1 h1:ogLJMz+qpzav7lGMh10LMvAkM/fAoGlaiiHYiFYdm80=
 golang.org/x/sys v0.0.0-20200615200032-f1bc736245b1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.2.0 h1:ljd4t30dBnAvMZaQCevtY0xLLD0A+bRZXbgLMLU1F/A=
+golang.org/x/sys v0.2.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=


### PR DESCRIPTION
Upgrade to use go1.19 as go1.17 is unmaintained, also update `golang.org/x/sys` to fix the build issue in [the homebrew version bump](https://github.com/Homebrew/homebrew-core/pull/115622)

error log as below
```
# golang.org/x/sys/unix
/Users/rui/Library/Caches/Homebrew/go_mod_cache/pkg/mod/golang.org/x/sys@v0.0.0-20200615200032-f1bc736245b1/unix/syscall_darwin.1_13.go:29:3: //go:linkname must refer to declared function or variable
/Users/rui/Library/Caches/Homebrew/go_mod_cache/pkg/mod/golang.org/x/sys@v0.0.0-20200615200032-f1bc736245b1/unix/zsyscall_darwin_arm64.1_13.go:27:3: //go:linkname must refer to declared function or variable
/Users/rui/Library/Caches/Homebrew/go_mod_cache/pkg/mod/golang.org/x/sys@v0.0.0-20200615200032-f1bc736245b1/unix/zsyscall_darwin_arm64.1_13.go:40:3: //go:linkname must refer to declared function or variable
/Users/rui/Library/Caches/Homebrew/go_mod_cache/pkg/mod/golang.org/x/sys@v0.0.0-20200615200032-f1bc736245b1/unix/zsyscall_darwin_arm64.go:28:3: //go:linkname must refer to declared function or variable
/Users/rui/Library/Caches/Homebrew/go_mod_cache/pkg/mod/golang.org/x/sys@v0.0.0-20200615200032-f1bc736245b1/unix/zsyscall_darwin_arm64.go:43:3: //go:linkname must refer to declared function or variable
/Users/rui/Library/Caches/Homebrew/go_mod_cache/pkg/mod/golang.org/x/sys@v0.0.0-20200615200032-f1bc736245b1/unix/zsyscall_darwin_arm64.go:59:3: //go:linkname must refer to declared function or variable
/Users/rui/Library/Caches/Homebrew/go_mod_cache/pkg/mod/golang.org/x/sys@v0.0.0-20200615200032-f1bc736245b1/unix/zsyscall_darwin_arm64.go:75:3: //go:linkname must refer to declared function or variable
/Users/rui/Library/Caches/Homebrew/go_mod_cache/pkg/mod/golang.org/x/sys@v0.0.0-20200615200032-f1bc736245b1/unix/zsyscall_darwin_arm64.go:90:3: //go:linkname must refer to declared function or variable
/Users/rui/Library/Caches/Homebrew/go_mod_cache/pkg/mod/golang.org/x/sys@v0.0.0-20200615200032-f1bc736245b1/unix/zsyscall_darwin_arm64.go:105:3: //go:linkname must refer to declared function or variable
/Users/rui/Library/Caches/Homebrew/go_mod_cache/pkg/mod/golang.org/x/sys@v0.0.0-20200615200032-f1bc736245b1/unix/zsyscall_darwin_arm64.go:121:3: //go:linkname must refer to declared function or variable
/Users/rui/Library/Caches/Homebrew/go_mod_cache/pkg/mod/golang.org/x/sys@v0.0.0-20200615200032-f1bc736245b1/unix/zsyscall_darwin_arm64.go:121:3: too many errors
```