### PR TITLE
feat: add save_prefix config

### DIFF
--- a/internal/pcsconfig/export.go
+++ b/internal/pcsconfig/export.go
@@ -77,6 +77,7 @@ func (c *PCSConfig) PrintTable() {
 		[]string{"savedir", c.SaveDir, "", "下载文件的储存目录"},
 		[]string{"enable_https", fmt.Sprint(c.EnableHTTPS), "true", "启用 https"},
 		[]string{"force_login_username", fmt.Sprint(c.ForceLogin), "留空", "强制登录指定用户名, 适用于tieba用户信息接口不可用的情况, 如登录正常请留空"},
+		[]string{"save_prefix", fmt.Sprint(c.SavePrefix), "", "指定各个账号下载到的子目录"},
 		[]string{"no_check", fmt.Sprint(c.NoCheck), "true", "关闭下载文件md5校验"},
 		[]string{"ignore_illegal", fmt.Sprint(c.IgnoreIllegal), "false", "关闭上传文件的文件名非法字符检查"},
 		[]string{"upload_policy", fmt.Sprint(c.UPolicy), "fail", "上传遇到重名文件时的处理策略, fail(默认，直接返回失败)、newcopy(重命名文件)、overwrite(覆盖)、skip(跳过)、rsync(仅跳过大小未变化的文件)"},

--- a/internal/pcsconfig/pcsconfig.go
+++ b/internal/pcsconfig/pcsconfig.go
@@ -51,6 +51,7 @@ type PCSConfig struct {
 	PCSAddr     string `json:"pcs_addr"`     // PCS服务器域名
 	PanUA       string `json:"pan_ua"`       // PAN浏览器标识
 	SaveDir     string `json:"savedir"`      // 下载储存路径
+	SavePrefix  string `json:"save_prefix"`          // 指定各个账号下载到的子目录
 	EnableHTTPS bool   `json:"enable_https"` // 启用https
 	ForceLogin  string `json:"force_login_username"` // 强制登录
 	Proxy       string `json:"proxy"`        // 代理
@@ -238,6 +239,7 @@ func (c *PCSConfig) InitDefaultConfig() {
 	c.EnableHTTPS = true
 	c.NoCheck = true
 	c.UPolicy = "fail"
+	c.SavePrefix = "{{.UID}}_{{trim .NAME}}"
 
 	// 设置默认的下载路径
 	switch runtime.GOOS {

--- a/main.go
+++ b/main.go
@@ -1975,6 +1975,9 @@ func main() {
 						if c.IsSet("savedir") {
 							pcsconfig.Config.SaveDir = c.String("savedir")
 						}
+						if c.IsSet("save_prefix") {
+							pcsconfig.Config.SavePrefix = c.String("save_prefix")
+						}
 						if c.IsSet("proxy") {
 							pcsconfig.Config.SetProxy(c.String("proxy"))
 						}
@@ -2029,6 +2032,10 @@ func main() {
 						cli.StringFlag{
 							Name:  "savedir",
 							Usage: "下载文件的储存目录",
+						},
+						cli.StringFlag{
+							Name:  "save_prefix",
+							Usage: "指定各个账号下载到的子目录 (默认为: {{.UID}}-{{trim .NAME}})",
 						},
 						cli.BoolFlag{
 							Name:  "enable_https",


### PR DESCRIPTION
我想让所有账号都下载到一个固定目录 `~/Downloads/baidupcs/` 但发现好像没法去掉 uid_name 这个子目录

加了个配置项能实现这个需求
```
config set --save_prefix baidupcs
```

related: https://github.com/qjfoidnh/BaiduPCS-Go/issues/169