### PR TITLE
feat: add --fs_id flag to transfer command

### DIFF
--- a/baidupcs/transfer.go
+++ b/baidupcs/transfer.go
@@ -21,6 +21,7 @@ type (
 		Download bool // 是否直接开始下载
 		Collect  bool // 多文件整合
 		Rname    bool // 随机改文件名
+		FsID     string // 指定fs_id转存
 	}
 )
 

--- a/internal/pcscommand/transfer.go
+++ b/internal/pcscommand/transfer.go
@@ -84,6 +84,14 @@ func RunShareTransfer(params []string, opt *baidupcs.TransferOption) {
 		fmt.Printf("%s失败: %s\n", baidupcs.OperationShareFileSavetoLocal, transMetas["ErrMsg"])
 		return
 	}
+
+	// 如果指定了 fs_id, 覆盖解析结果
+	if opt.FsID != "" {
+		transMetas["fs_id"] = "[" + opt.FsID + "]"
+		transMetas["filename"] = "user_specified_file" // 名字可能不准确，但不影响转存
+		transMetas["item_num"] = "1"
+	}
+
 	transMetas["path"] = GetActiveUser().Workdir
 	if transMetas["item_num"] != "1" && opt.Collect {
 		transMetas["filename"] += "等文件"

--- a/main.go
+++ b/main.go
@@ -1354,6 +1354,7 @@ func main() {
 					Download: c.Bool("download"),
 					Collect:  c.Bool("collect"),
 					Rname:    c.Bool("rname"),
+					FsID:     c.String("fs_id"),
 				}
 				pcscommand.RunShareTransfer(c.Args(), opt)
 				return nil
@@ -1370,6 +1371,10 @@ func main() {
 				cli.BoolFlag{
 					Name:  "rname",
 					Usage: "秒传随机替换4位文件名提高成功率",
+				},
+				cli.StringFlag{
+					Name:  "fs_id",
+					Usage: "指定特定fs_id进行转存(用于绕过大文件夹数量限制)",
 				},
 			},
 		},


### PR DESCRIPTION
原版中，transfer默认转存分享链接中所有文件，容易因为文件数量过多导致转存失败，增加fs_id可以提升transfer的易用性。

```bash
"./baidupcs-go" transfer --fs_id=123456789012345 "https://pan.baidu.com/s/12345678901234567890123?pwd=1234"
```

存在fs_id参数时，分享链接仅用作检验用户合法性，指定的fs_id会代替原本解析得到的fs_id。