### PR TITLE
Use dynamic progress dashboard for downloads and uploads, closes #495

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+BaiduPCS-Go

--- a/internal/pcscommand/download.go
+++ b/internal/pcscommand/download.go
@@ -33,6 +33,7 @@ type (
 		ModifyMTime          bool
 		FullPath             bool
 		LinkPrefer           int
+		IsLineByLine         bool
 	}
 
 	// LocateDownloadOption 获取下载链接可选参数
@@ -140,7 +141,10 @@ func RunDownload(paths []string, options *DownloadOptions) {
 	sort.Slice(file_dir_list, func(i, j int) bool {
 		return file_dir_list[i].Size < file_dir_list[j].Size
 	})
-	for _,v := range file_dir_list {
+	// 列表展示所有待下载文件及对应的保存位置
+	tb := pcstable.NewTable(os.Stdout)
+	tb.SetHeader([]string{"#", "文件路径", "保存位置"})
+	for _, v := range file_dir_list {
 		newCfg := *cfg
 		unit := pcsdownload.DownloadTaskUnit{
 			Cfg:                  &newCfg, // 复制一份新的cfg
@@ -153,14 +157,13 @@ func RunDownload(paths []string, options *DownloadOptions) {
 			IsExecutedPermission: options.IsExecutedPermission,
 			IsOverwrite:          options.IsOverwrite,
 			NoCheck:              options.NoCheck,
+			IsLineByLine:         options.IsLineByLine,
 			DlinkPrefer:          options.LinkPrefer,
 			DownloadMode:         options.DownloadMode,
 			ModifyMTime:          options.ModifyMTime,
 			PcsPath:              v.Path,
 			FileInfo:             v,
 		}
-		// 设置下载并发数
-		executor.SetParallel(loadCount)
 		// 设置储存的路径
 		vPath := v.Path
 		if !options.FullPath {
@@ -172,12 +175,18 @@ func RunDownload(paths []string, options *DownloadOptions) {
 			// 使用默认的保存路径
 			unit.SavePath = GetActiveUser().GetSavePath(vPath)
 		}
+
 		info := executor.Append(&unit, options.MaxRetry)
-		fmt.Printf("[%s] 加入下载队列: %s\n", info.Id(), v.Path)
+		tb.Append([]string{info.Id(), v.Path, unit.SavePath})
 	}
+	executor.SetParallel(loadCount)
+	tb.Render()
 
 	// 开始计时
 	statistic.StartTimer()
+
+	// 设置是否启用动态面板
+	pcsdownload.GetProgressManager().SetEnabled(!options.IsLineByLine)
 
 	// 开始执行
 	executor.Execute()

--- a/internal/pcscommand/upload.go
+++ b/internal/pcscommand/upload.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"github.com/qjfoidnh/BaiduPCS-Go/baidupcs"
 	"github.com/qjfoidnh/BaiduPCS-Go/internal/pcsconfig"
+	"github.com/qjfoidnh/BaiduPCS-Go/internal/pcsfunctions/pcsdownload"
 	"github.com/qjfoidnh/BaiduPCS-Go/internal/pcsfunctions/pcsupload"
 	"github.com/qjfoidnh/BaiduPCS-Go/pcstable"
 	"github.com/qjfoidnh/BaiduPCS-Go/pcsutil"
@@ -31,6 +32,7 @@ type (
 		NoSplitFile     bool   // 禁用分片上传
 		Policy          string // 同名文件处理策略
 		NoFilenameCheck bool   // 禁用文件名合法性检查
+		IsLineByLine    bool   // 是否逐行输出
 	}
 )
 
@@ -143,6 +145,7 @@ func RunUpload(localPaths []string, savePath string, opt *UploadOptions) {
 				NoSplitFile:       opt.NoSplitFile,
 				UploadStatistic:   statistic,
 				Policy:            opt.Policy,
+				IsLineByLine:      opt.IsLineByLine,
 			}, opt.MaxRetry)
 			if LoadCount >= opt.Load {
 				LoadCount = opt.Load
@@ -159,6 +162,10 @@ func RunUpload(localPaths []string, savePath string, opt *UploadOptions) {
 
 	// 设置上传文件并发数
 	executor.SetParallel(LoadCount)
+
+	// Set dynamic dashboard status
+	pcsdownload.GetProgressManager().SetEnabled(!opt.IsLineByLine)
+
 	// 执行上传任务
 	executor.Execute()
 

--- a/internal/pcsfunctions/pcsdownload/download_task_unit.go
+++ b/internal/pcsfunctions/pcsdownload/download_task_unit.go
@@ -3,6 +3,14 @@ package pcsdownload
 import (
 	"errors"
 	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
 	"github.com/qjfoidnh/BaiduPCS-Go/baidupcs"
 	"github.com/qjfoidnh/BaiduPCS-Go/baidupcs/pcserror"
 	"github.com/qjfoidnh/BaiduPCS-Go/internal/pcsconfig"
@@ -14,13 +22,6 @@ import (
 	"github.com/qjfoidnh/BaiduPCS-Go/requester"
 	"github.com/qjfoidnh/BaiduPCS-Go/requester/downloader"
 	"github.com/qjfoidnh/BaiduPCS-Go/requester/transfer"
-	"io"
-	"net/http"
-	"os"
-	"path/filepath"
-	"strconv"
-	"strings"
-	"time"
 )
 
 type (
@@ -498,7 +499,7 @@ func (dtu *DownloadTaskUnit) Run() (result *taskframework.TaskUnitRunResult) {
 		return
 	}
 
-	GetProgressManager().Printf("[%s] 准备下载: %s\n", dtu.taskInfo.Id(), dtu.PcsPath)
+	// GetProgressManager().Printf("[%s] 准备下载: %s\n", dtu.taskInfo.Id(), dtu.PcsPath)
 
 	if !dtu.Cfg.IsTest && !dtu.IsOverwrite && FileExist(dtu.SavePath) {
 		GetProgressManager().Printf("[%s] 文件已经存在: %s, 跳过...\n", dtu.taskInfo.Id(), dtu.SavePath)
@@ -508,7 +509,7 @@ func (dtu *DownloadTaskUnit) Run() (result *taskframework.TaskUnitRunResult) {
 
 	if !dtu.Cfg.IsTest {
 		// 不是测试下载, 输出下载路径
-		GetProgressManager().Printf("[%s] 将会下载到路径: %s\n\n", dtu.taskInfo.Id(), dtu.SavePath)
+		// GetProgressManager().Printf("[%s] 将会下载到路径: %s\n\n", dtu.taskInfo.Id(), dtu.SavePath)
 	}
 
 	var ok bool

--- a/internal/pcsfunctions/pcsdownload/download_task_unit.go
+++ b/internal/pcsfunctions/pcsdownload/download_task_unit.go
@@ -44,6 +44,7 @@ type (
 		IsExecutedPermission bool // 下载成功后是否加上执行权限
 		IsOverwrite          bool // 是否覆盖已存在的文件
 		NoCheck              bool // 不校验文件
+		IsLineByLine         bool // 是否逐行输出
 		DlinkPrefer          int  // 使用所有备选下载链接中的第几个链接
 		ModifyMTime          bool // 下载的文件mtime修改为与网盘一致
 
@@ -182,19 +183,19 @@ func (dtu *DownloadTaskUnit) download(downloadURL string, client *requester.HTTP
 
 		if !isComplete {
 			// 如果未完成下载, 就输出
-			fmt.Print(builder.String())
+			GetProgressManager().Update(dtu.taskInfo.Id(), builder.String())
 		}
 	})
 
 	der.OnExecute(func() {
 		if dtu.Cfg.IsTest {
-			fmt.Printf("[%s] 测试下载开始\n\n", dtu.taskInfo.Id())
+			GetProgressManager().Printf("[%s] 测试下载开始\n", dtu.taskInfo.Id())
 		}
 	})
 
 	err = der.Execute()
 	isComplete = true
-	fmt.Print("\n")
+	GetProgressManager().Remove(dtu.taskInfo.Id())
 
 	if err != nil {
 		// 下载发生错误
@@ -219,13 +220,13 @@ func (dtu *DownloadTaskUnit) download(downloadURL string, client *requester.HTTP
 		if dtu.IsExecutedPermission {
 			err = file.Chmod(0766)
 			if err != nil {
-				fmt.Printf("[%s] 警告, 加执行权限错误: %s\n", dtu.taskInfo.Id(), err)
+				GetProgressManager().Printf("[%s] 警告, 加执行权限错误: %s\n", dtu.taskInfo.Id(), err)
 			}
 		}
 
-		fmt.Printf("[%s] 下载完成, 保存位置: %s\n", dtu.taskInfo.Id(), dtu.SavePath)
+		GetProgressManager().Printf("[%s] 下载完成, 保存位置: %s\n", dtu.taskInfo.Id(), dtu.SavePath)
 	} else {
-		fmt.Printf("[%s] 测试下载结束\n", dtu.taskInfo.Id())
+		GetProgressManager().Printf("[%s] 测试下载结束\n", dtu.taskInfo.Id())
 	}
 
 	return nil
@@ -364,13 +365,13 @@ func (dtu *DownloadTaskUnit) checkFileValid(result *taskframework.TaskUnitRunRes
 	}
 	if dtu.Cfg.IsTest || dtu.NoCheck {
 		// 不检测文件有效性
-		fmt.Printf("[%s] 跳过文件有效性检验\n", dtu.taskInfo.Id())
+		GetProgressManager().Printf("[%s] 跳过文件有效性检验\n", dtu.taskInfo.Id())
 		return true
 	}
 
 	if dtu.FileInfo.Size >= 128*converter.MB {
 		// 大文件, 输出一句提示消息
-		fmt.Printf("[%s] 开始检验文件有效性, 请稍候...\n", dtu.taskInfo.Id())
+		GetProgressManager().Printf("[%s] 开始检验文件有效性, 请稍候...\n", dtu.taskInfo.Id())
 	}
 
 	// 就在这里处理校验出错
@@ -383,7 +384,7 @@ func (dtu *DownloadTaskUnit) checkFileValid(result *taskframework.TaskUnitRunRes
 			// 文件不支持校验
 			result.ResultMessage = "检验文件有效性"
 			result.Err = err
-			fmt.Printf("[%s] 检验文件有效性: %s\n", dtu.taskInfo.Id(), err)
+			GetProgressManager().Printf("[%s] 检验文件有效性: %s\n", dtu.taskInfo.Id(), err)
 			return true
 		case ErrDownloadFileBanned:
 			// 违规文件
@@ -401,7 +402,7 @@ func (dtu *DownloadTaskUnit) checkFileValid(result *taskframework.TaskUnitRunRes
 		}
 	}
 
-	fmt.Printf("[%s] 检验文件有效性成功: %s\n", dtu.taskInfo.Id(), dtu.SavePath)
+	GetProgressManager().Printf("[%s] 检验文件有效性成功: %s\n", dtu.taskInfo.Id(), dtu.SavePath)
 	return true
 }
 
@@ -409,10 +410,10 @@ func (dtu *DownloadTaskUnit) OnRetry(lastRunResult *taskframework.TaskUnitRunRes
 	// 输出错误信息
 	if lastRunResult.Err == nil {
 		// result中不包含Err, 忽略输出
-		fmt.Printf("[%s] %s, 重试 %d/%d\n", dtu.taskInfo.Id(), lastRunResult.ResultMessage, dtu.taskInfo.Retry(), dtu.taskInfo.MaxRetry())
+		GetProgressManager().Printf("[%s] %s, 重试 %d/%d\n", dtu.taskInfo.Id(), lastRunResult.ResultMessage, dtu.taskInfo.Retry(), dtu.taskInfo.MaxRetry())
 		return
 	}
-	fmt.Printf("[%s] %s, %s, 重试 %d/%d\n", dtu.taskInfo.Id(), lastRunResult.ResultMessage, lastRunResult.Err, dtu.taskInfo.Retry(), dtu.taskInfo.MaxRetry())
+	GetProgressManager().Printf("[%s] %s, %s, 重试 %d/%d\n", dtu.taskInfo.Id(), lastRunResult.ResultMessage, lastRunResult.Err, dtu.taskInfo.Retry(), dtu.taskInfo.MaxRetry())
 }
 
 func (dtu *DownloadTaskUnit) OnSuccess(lastRunResult *taskframework.TaskUnitRunResult) {
@@ -422,10 +423,10 @@ func (dtu *DownloadTaskUnit) OnFailed(lastRunResult *taskframework.TaskUnitRunRe
 	// 失败
 	if lastRunResult.Err == nil {
 		// result中不包含Err, 忽略输出
-		fmt.Printf("[%s] %s\n", dtu.taskInfo.Id(), lastRunResult.ResultMessage)
+		GetProgressManager().Printf("[%s] %s\n", dtu.taskInfo.Id(), lastRunResult.ResultMessage)
 		return
 	}
-	fmt.Printf("[%s] %s, %s\n", dtu.taskInfo.Id(), lastRunResult.ResultMessage, lastRunResult.Err)
+	GetProgressManager().Printf("[%s] %s, %s\n", dtu.taskInfo.Id(), lastRunResult.ResultMessage, lastRunResult.Err)
 }
 
 func (dtu *DownloadTaskUnit) OnComplete(lastRunResult *taskframework.TaskUnitRunResult) {
@@ -454,8 +455,7 @@ func (dtu *DownloadTaskUnit) Run() (result *taskframework.TaskUnitRunResult) {
 	}
 
 	// 输出文件信息
-	fmt.Print("\n")
-	fmt.Printf("[%s] ----\n%s\n", dtu.taskInfo.Id(), dtu.FileInfo.String())
+	GetProgressManager().Printf("\n[%s] ----\n%s\n", dtu.taskInfo.Id(), dtu.FileInfo.String())
 
 	// 如果是一个目录, 将子文件和子目录加入队列
 	if dtu.FileInfo.Isdir {
@@ -498,17 +498,17 @@ func (dtu *DownloadTaskUnit) Run() (result *taskframework.TaskUnitRunResult) {
 		return
 	}
 
-	fmt.Printf("[%s] 准备下载: %s\n", dtu.taskInfo.Id(), dtu.PcsPath)
+	GetProgressManager().Printf("[%s] 准备下载: %s\n", dtu.taskInfo.Id(), dtu.PcsPath)
 
 	if !dtu.Cfg.IsTest && !dtu.IsOverwrite && FileExist(dtu.SavePath) {
-		fmt.Printf("[%s] 文件已经存在: %s, 跳过...\n", dtu.taskInfo.Id(), dtu.SavePath)
+		GetProgressManager().Printf("[%s] 文件已经存在: %s, 跳过...\n", dtu.taskInfo.Id(), dtu.SavePath)
 		result.Succeed = true // 执行成功
 		return
 	}
 
 	if !dtu.Cfg.IsTest {
 		// 不是测试下载, 输出下载路径
-		fmt.Printf("[%s] 将会下载到路径: %s\n\n", dtu.taskInfo.Id(), dtu.SavePath)
+		GetProgressManager().Printf("[%s] 将会下载到路径: %s\n\n", dtu.taskInfo.Id(), dtu.SavePath)
 	}
 
 	var ok bool

--- a/internal/pcsfunctions/pcsdownload/progress_manager.go
+++ b/internal/pcsfunctions/pcsdownload/progress_manager.go
@@ -1,0 +1,141 @@
+package pcsdownload
+
+import (
+	"fmt"
+	"github.com/mattn/go-isatty"
+	"github.com/mattn/go-runewidth"
+	"golang.org/x/sys/unix"
+	"os"
+	"sort"
+	"strings"
+	"sync"
+)
+
+// ProgressManager maintains a list of concurrent download tasks and renders their progress
+// at the bottom of the terminal without scrolling the command history.
+type ProgressManager struct {
+	mu            sync.Mutex
+	activeTasks   map[string]string
+	taskIDs       []string
+	lastLineCount int
+	isTerminal    bool
+	enabled       bool
+}
+
+var (
+	globalProgressManager *ProgressManager
+	pmOnce                sync.Once
+)
+
+// GetProgressManager returns the singleton instance of ProgressManager.
+func GetProgressManager() *ProgressManager {
+	pmOnce.Do(func() {
+		globalProgressManager = &ProgressManager{
+			activeTasks: make(map[string]string),
+			isTerminal:  isatty.IsTerminal(os.Stdout.Fd()),
+		}
+	})
+	return globalProgressManager
+}
+
+// SetEnabled activates the dynamic dashboard if the output is a terminal.
+func (pm *ProgressManager) SetEnabled(enabled bool) {
+	pm.enabled = enabled && pm.isTerminal
+}
+
+// Update records or updates the progress string for a specific task and triggers a redraw.
+func (pm *ProgressManager) Update(id string, status string) {
+	if !pm.enabled {
+		fmt.Print(status)
+		return
+	}
+	pm.mu.Lock()
+	defer pm.mu.Unlock()
+
+	if _, ok := pm.activeTasks[id]; !ok {
+		pm.taskIDs = append(pm.taskIDs, id)
+		sort.Strings(pm.taskIDs)
+	}
+	pm.activeTasks[id] = status
+	pm.draw()
+}
+
+// Remove cleans up a finished task's entry from the dashboard.
+func (pm *ProgressManager) Remove(id string) {
+	if !pm.enabled {
+		return
+	}
+	pm.mu.Lock()
+	defer pm.mu.Unlock()
+
+	if _, ok := pm.activeTasks[id]; ok {
+		delete(pm.activeTasks, id)
+		for i, tid := range pm.taskIDs {
+			if tid == id {
+				pm.taskIDs = append(pm.taskIDs[:i], pm.taskIDs[i+1:]...)
+				break
+			}
+		}
+		pm.draw()
+	}
+}
+
+// Printf displays log messages above the dynamic progress dashboard.
+func (pm *ProgressManager) Printf(format string, a ...interface{}) {
+	if !pm.enabled {
+		fmt.Printf(format, a...)
+		return
+	}
+	pm.mu.Lock()
+	defer pm.mu.Unlock()
+
+	// Clear the existing dashboard area before printing log messages.
+	if pm.lastLineCount > 0 {
+		fmt.Printf("\033[%dA\033[J", pm.lastLineCount)
+	}
+
+	fmt.Printf(format, a...)
+
+	// Reset tracking and redraw the dashboard at the new bottom position.
+	pm.lastLineCount = 0
+	pm.draw()
+}
+
+// getTermWidth returns the current width of the terminal.
+func (pm *ProgressManager) getTermWidth() int {
+	ws, err := unix.IoctlGetWinsize(int(os.Stdout.Fd()), unix.TIOCGWINSZ)
+	if err != nil {
+		return 80 // Default fallback
+	}
+	return int(ws.Col)
+}
+
+// draw performs the actual rendering of the dynamic progress lines.
+func (pm *ProgressManager) draw() {
+	// Move cursor up to the dashboard start position.
+	if pm.lastLineCount > 0 {
+		fmt.Printf("\033[%dA", pm.lastLineCount)
+	}
+
+	// Use \033[J to clear everything from the current cursor position to the bottom.
+	fmt.Print("\033[J")
+
+	width := pm.getTermWidth()
+	totalLines := 0
+	for _, id := range pm.taskIDs {
+		str := pm.activeTasks[id]
+		lines := strings.Split(strings.TrimSuffix(str, "\n"), "\n")
+		for _, line := range lines {
+			fmt.Print("\r")
+			// Truncate line to fit terminal width to avoid wrapping.
+			if runewidth.StringWidth(line) > width {
+				line = runewidth.Truncate(line, width, "...")
+			}
+			fmt.Println(line)
+			totalLines++
+		}
+	}
+
+	pm.lastLineCount = totalLines
+	os.Stdout.Sync()
+}

--- a/internal/pcsfunctions/pcsupload/upload_task_unit.go
+++ b/internal/pcsfunctions/pcsupload/upload_task_unit.go
@@ -6,6 +6,10 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"path"
+	"strings"
+	"time"
+
 	"github.com/qjfoidnh/BaiduPCS-Go/baidupcs"
 	"github.com/qjfoidnh/BaiduPCS-Go/baidupcs/pcserror"
 	"github.com/qjfoidnh/BaiduPCS-Go/internal/pcsconfig"
@@ -16,9 +20,6 @@ import (
 	"github.com/qjfoidnh/BaiduPCS-Go/pcsutil/taskframework"
 	"github.com/qjfoidnh/BaiduPCS-Go/requester/rio"
 	"github.com/qjfoidnh/BaiduPCS-Go/requester/uploader"
-	"path"
-	"strings"
-	"time"
 )
 
 type (
@@ -263,7 +264,7 @@ func (utu *UploadTaskUnit) rapidUpload() (isContinue bool, result *taskframework
 		return
 	}
 
-	pcsdownload.GetProgressManager().Printf("[%s] 开始上传文件...\n\n", utu.taskInfo.Id())
+	//pcsdownload.GetProgressManager().Printf("[%s] 开始上传文件...\n\n", utu.taskInfo.Id())
 
 	// 保存秒传信息
 	if utu.state.Uploadid == "" {

--- a/internal/pcsfunctions/pcsupload/upload_task_unit.go
+++ b/internal/pcsfunctions/pcsupload/upload_task_unit.go
@@ -10,6 +10,7 @@ import (
 	"github.com/qjfoidnh/BaiduPCS-Go/baidupcs/pcserror"
 	"github.com/qjfoidnh/BaiduPCS-Go/internal/pcsconfig"
 	"github.com/qjfoidnh/BaiduPCS-Go/internal/pcsfunctions"
+	"github.com/qjfoidnh/BaiduPCS-Go/internal/pcsfunctions/pcsdownload"
 	"github.com/qjfoidnh/BaiduPCS-Go/pcsutil/checksum"
 	"github.com/qjfoidnh/BaiduPCS-Go/pcsutil/converter"
 	"github.com/qjfoidnh/BaiduPCS-Go/pcsutil/taskframework"
@@ -37,6 +38,7 @@ type (
 		NoRapidUpload     bool   // 禁用秒传
 		NoSplitFile       bool   // 禁用分片上传
 		Policy            string // 上传重名文件策略
+		IsLineByLine      bool   // 是否逐行输出
 
 		UploadStatistic *UploadStatistic
 
@@ -88,13 +90,13 @@ func (utu *UploadTaskUnit) prepareFile() {
 	utu.state = &uploader.InstanceState{}
 
 	if utu.LocalFileChecksum.Length >= baidupcs.RecommendedUploadSize {
-		fmt.Printf("[%s] 文件超过32GB, 上传有可能失败, 建议分割文件...\n", utu.taskInfo.Id())
+		pcsdownload.GetProgressManager().Printf("[%s] 文件超过32GB, 上传有可能失败, 建议分割文件...\n", utu.taskInfo.Id())
 	}
 
 	if utu.LocalFileChecksum.Length > baidupcs.MinCheckLeftSpaceThreshold {
 		freeSpace, err := utu.PCS.SpaceLeftInfo()
 		if err == nil && freeSpace < utu.LocalFileChecksum.Length {
-			fmt.Printf("[%s] 目标文件大小超过剩余空间, 跳过...\n", utu.taskInfo.Id())
+			pcsdownload.GetProgressManager().Printf("[%s] 目标文件大小超过剩余空间, 跳过...\n", utu.taskInfo.Id())
 			utu.Step = JustGoon
 			return
 		}
@@ -106,11 +108,11 @@ func (utu *UploadTaskUnit) prepareFile() {
 		if pcsError != nil {
 			errcode := pcsError.GetRemoteErrCode()
 			if errcode != 114514 && errcode != 1919810 {
-				fmt.Printf("[%s] 跳过秒传失败, 开始秒传...\n", utu.taskInfo.Id())
+				pcsdownload.GetProgressManager().Printf("[%s] 跳过秒传失败, 开始秒传...\n", utu.taskInfo.Id())
 				utu.Step = StepUploadRapidUpload
 				return
 			} else {
-				fmt.Printf("[%s] 目标文件已存在, 跳过...\n", utu.taskInfo.Id())
+				pcsdownload.GetProgressManager().Printf("[%s] 目标文件已存在, 跳过...\n", utu.taskInfo.Id())
 				utu.Step = JustGoon
 				return
 			}
@@ -157,7 +159,7 @@ func (utu *UploadTaskUnit) rapidUpload() (isContinue bool, result *taskframework
 		}
 	}
 
-	fmt.Printf("[%s] 开始计算文件元信息, 请稍候...\n", utu.taskInfo.Id())
+	pcsdownload.GetProgressManager().Printf("[%s] 开始计算文件元信息, 请稍候...\n", utu.taskInfo.Id())
 
 	// 经测试, 文件的 crc32 值并非秒传文件所必需
 	if utu.LocalFileChecksum.LocalFileMeta.MD5 == nil || utu.LocalFileChecksum.LocalFileMeta.SliceMD5 == nil {
@@ -177,7 +179,7 @@ func (utu *UploadTaskUnit) rapidUpload() (isContinue bool, result *taskframework
 				decodedMD5, _ := hex.DecodeString(fd.MD5)
 				// TODO: fd.MD5 有可能是错误的
 				if (utu.Policy == baidupcs.SkipPolicy) || (bytes.Compare(decodedMD5, utu.LocalFileChecksum.MD5) == 0) {
-					fmt.Printf("[%s] 目标文件, %s, 已存在, 跳过...\n", utu.taskInfo.Id(), utu.SavePath)
+					pcsdownload.GetProgressManager().Printf("[%s] 目标文件, %s, 已存在, 跳过...\n", utu.taskInfo.Id(), utu.SavePath)
 					result.Succeed = true // 成功
 					return
 				}
@@ -208,7 +210,7 @@ func (utu *UploadTaskUnit) rapidUpload() (isContinue bool, result *taskframework
 
 	blockSize := getBlockSize(utu.LocalFileChecksum.Length)
 
-	fmt.Printf("[%s] 开始计算文件分块md5, 请稍候...\n", utu.taskInfo.Id())
+	pcsdownload.GetProgressManager().Printf("[%s] 开始计算文件分块md5, 请稍候...\n", utu.taskInfo.Id())
 	if utu.LocalFileChecksum.LocalFileMeta.BlocksList == nil || len(utu.LocalFileChecksum.LocalFileMeta.BlocksList) == 0 {
 		err = utu.LocalFileChecksum.CalculateChunkedSum(blockSize)
 		if err != nil {
@@ -224,7 +226,7 @@ func (utu *UploadTaskUnit) rapidUpload() (isContinue bool, result *taskframework
 		offset, dataLength, utu.LocalFileChecksum.Length, currentTime, utu.LocalFileChecksum.BlocksList)
 	if pcsError == nil {
 		if jsonData.ReturnType == 2 {
-			fmt.Printf("[%s] 秒传成功, 保存到网盘路径: %s\n\n", utu.taskInfo.Id(), utu.SavePath)
+			pcsdownload.GetProgressManager().Printf("[%s] 秒传成功, 保存到网盘路径: %s\n\n", utu.taskInfo.Id(), utu.SavePath)
 			// 统计
 			utu.UploadStatistic.AddTotalSize(utu.LocalFileChecksum.Length)
 			result.Succeed = true // 成功
@@ -261,7 +263,7 @@ func (utu *UploadTaskUnit) rapidUpload() (isContinue bool, result *taskframework
 		return
 	}
 
-	fmt.Printf("[%s] 开始上传文件...\n\n", utu.taskInfo.Id())
+	pcsdownload.GetProgressManager().Printf("[%s] 开始上传文件...\n\n", utu.taskInfo.Id())
 
 	// 保存秒传信息
 	if utu.state.Uploadid == "" {
@@ -293,6 +295,9 @@ func (utu *UploadTaskUnit) upload() (result *taskframework.TaskUnitRunResult) {
 	if utu.state != nil {
 		muer.SetInstanceState(utu.state)
 	}
+
+	// Dynamic progress reporting
+	isComplete := false
 	muer.OnUploadStatusEvent(func(status uploader.Status, updateChan <-chan struct{}) {
 		select {
 		case <-updateChan:
@@ -303,19 +308,25 @@ func (utu *UploadTaskUnit) upload() (result *taskframework.TaskUnitRunResult) {
 		default:
 		}
 
-		fmt.Printf(utu.PrintFormat, utu.taskInfo.Id(),
+		statusStr := fmt.Sprintf(utu.PrintFormat, utu.taskInfo.Id(),
 			converter.ConvertFileSize(status.Uploaded(), 2),
 			converter.ConvertFileSize(status.TotalSize(), 2),
 			converter.ConvertFileSize(status.SpeedsPerSecond(), 2),
 			status.TimeElapsed(),
 		)
+
+		if !isComplete {
+			pcsdownload.GetProgressManager().Update(utu.taskInfo.Id(), statusStr)
+		}
 	})
 
 	// result
 	result = &taskframework.TaskUnitRunResult{}
 	muer.OnSuccess(func() {
-		fmt.Printf("\n")
-		fmt.Printf("[%s] 上传文件成功, 保存到网盘路径: %s\n", utu.taskInfo.Id(), utu.SavePath)
+		isComplete = true
+		pcsdownload.GetProgressManager().Remove(utu.taskInfo.Id())
+
+		pcsdownload.GetProgressManager().Printf("[%s] 上传文件成功, 保存到网盘路径: %s\n", utu.taskInfo.Id(), utu.SavePath)
 		// 统计
 		utu.UploadStatistic.AddTotalSize(utu.LocalFileChecksum.Length)
 		utu.UploadingDatabase.Delete(&utu.LocalFileChecksum.LocalFileMeta) // 删除
@@ -398,6 +409,8 @@ func (utu *UploadTaskUnit) upload() (result *taskframework.TaskUnitRunResult) {
 		return
 	})
 	muer.Execute()
+	isComplete = true
+	pcsdownload.GetProgressManager().Remove(utu.taskInfo.Id())
 
 	return
 }
@@ -406,10 +419,10 @@ func (utu *UploadTaskUnit) OnRetry(lastRunResult *taskframework.TaskUnitRunResul
 	// 输出错误信息
 	if lastRunResult.Err == nil {
 		// result中不包含Err, 忽略输出
-		fmt.Printf("[%s] %s, 重试 %d/%d\n", utu.taskInfo.Id(), lastRunResult.ResultMessage, utu.taskInfo.Retry(), utu.taskInfo.MaxRetry())
+		pcsdownload.GetProgressManager().Printf("[%s] %s, 重试 %d/%d\n", utu.taskInfo.Id(), lastRunResult.ResultMessage, utu.taskInfo.Retry(), utu.taskInfo.MaxRetry())
 		return
 	}
-	fmt.Printf("[%s] %s, %s, 重试 %d/%d\n", utu.taskInfo.Id(), lastRunResult.ResultMessage, lastRunResult.Err, utu.taskInfo.Retry(), utu.taskInfo.MaxRetry())
+	pcsdownload.GetProgressManager().Printf("[%s] %s, %s, 重试 %d/%d\n", utu.taskInfo.Id(), lastRunResult.ResultMessage, lastRunResult.Err, utu.taskInfo.Retry(), utu.taskInfo.MaxRetry())
 }
 
 func (utu *UploadTaskUnit) OnSuccess(lastRunResult *taskframework.TaskUnitRunResult) {
@@ -419,10 +432,10 @@ func (utu *UploadTaskUnit) OnFailed(lastRunResult *taskframework.TaskUnitRunResu
 	// 失败
 	if lastRunResult.Err == nil {
 		// result中不包含Err, 忽略输出
-		fmt.Printf("[%s] %s\n", utu.taskInfo.Id(), lastRunResult.ResultMessage)
+		pcsdownload.GetProgressManager().Printf("[%s] %s\n", utu.taskInfo.Id(), lastRunResult.ResultMessage)
 		return
 	}
-	fmt.Printf("[%s] %s, %s\n", utu.taskInfo.Id(), lastRunResult.ResultMessage, lastRunResult.Err)
+	pcsdownload.GetProgressManager().Printf("[%s] %s, %s\n", utu.taskInfo.Id(), lastRunResult.ResultMessage, lastRunResult.Err)
 }
 
 func (utu *UploadTaskUnit) OnComplete(lastRunResult *taskframework.TaskUnitRunResult) {
@@ -433,16 +446,16 @@ func (utu *UploadTaskUnit) RetryWait() time.Duration {
 }
 
 func (utu *UploadTaskUnit) Run() (result *taskframework.TaskUnitRunResult) {
-	fmt.Printf("[%s] 准备上传: %s\n", utu.taskInfo.Id(), utu.LocalFileChecksum.Path)
+	pcsdownload.GetProgressManager().Printf("[%s] 准备上传: %s\n", utu.taskInfo.Id(), utu.LocalFileChecksum.Path)
 
 	if utu.LocalFileChecksum.Length > baidupcs.MaxUploadSize {
-		fmt.Printf("[%s] 文件大小超过128G, 无法上传, 跳过...\n", utu.taskInfo.Id())
+		pcsdownload.GetProgressManager().Printf("[%s] 文件大小超过128G, 无法上传, 跳过...\n", utu.taskInfo.Id())
 		return
 	}
 
 	err := utu.LocalFileChecksum.OpenPath()
 	if err != nil {
-		fmt.Printf("[%s] 文件不可读, 错误信息: %s, 跳过...\n", utu.taskInfo.Id(), err)
+		pcsdownload.GetProgressManager().Printf("[%s] 文件不可读, 错误信息: %s, 跳过...\n", utu.taskInfo.Id(), err)
 		return
 	}
 	defer utu.LocalFileChecksum.Close() // 关闭文件

--- a/main.go
+++ b/main.go
@@ -1222,6 +1222,7 @@ func main() {
 					Load:          c.Int("l"),
 					NoRapidUpload: c.Bool("norapid"),
 					Policy:        c.String("policy"),
+					IsLineByLine:  c.Bool("lbl"),
 				})
 				return nil
 			},
@@ -1246,6 +1247,10 @@ func main() {
 				cli.StringFlag{
 					Name:  "policy",
 					Usage: fmt.Sprintf("对同名文件的处理策略 (default: %s), %s, %s", baidupcs.SkipPolicy, baidupcs.OverWritePolicy, baidupcs.RsyncPolicy),
+				},
+				cli.BoolFlag{
+					Name:  "lbl",
+					Usage: "line-by-line progress update, 逐行打印进度更新",
 				},
 			},
 		},

--- a/main.go
+++ b/main.go
@@ -1102,6 +1102,7 @@ func main() {
 					LinkPrefer:           c.Int("dindex"),
 					ModifyMTime:          c.Bool("mtime"),
 					FullPath:             c.Bool("fullpath"),
+					IsLineByLine:         c.Bool("lbl"),
 				}
 
 				pcscommand.RunDownload(c.Args(), do)
@@ -1166,6 +1167,10 @@ func main() {
 				cli.BoolFlag{
 					Name:  "fullpath",
 					Usage: "以网盘完整路径保存到本地",
+				},
+				cli.BoolFlag{
+					Name:  "lbl",
+					Usage: "line-by-line progress update, 逐行打印进度更新",
 				},
 			},
 		},


### PR DESCRIPTION
This prevent flooding of the scroll-back buffer, which allows for a much cleaner and more professional-looking progress display during concurrent downloads and uploads. 

closes #495.