### PR TITLE
fix: remove invalid limit param causing 31023 error in file list API

### DIFF
--- a/baidupcs/prepare.go
+++ b/baidupcs/prepare.go
@@ -172,7 +172,6 @@ func (pcs *BaiduPCS) PrepareFilesDirectoriesList(path string, options *OrderOpti
 		"path":  path,
 		"by":    *(*string)(unsafe.Pointer(&options.By)),
 		"order": *(*string)(unsafe.Pointer(&options.Order)),
-		"limit": "0-2147483647",
 	})
 	baiduPCSVerbose.Infof("%s URL: %s\n", OperationFilesDirectoriesList, pcsURL)
 


### PR DESCRIPTION
## Problem

Baidu's server recently tightened parameter validation. The `PrepareFilesDirectoriesList` function was sending `limit=0-2147483647` in the request, which is now rejected with error code **31023 (param error)**.

This affects both:
- The `ls` command (directly calls file list API)
- The `upload` command (calls file list API during rapid-upload check to see if file already exists in destination)

Related issue: #501

## Fix

Remove the `limit` parameter from the `generatePCSURL` call in `baidupcs/prepare.go`, keeping only `path`, `by`, and `order`.

```go
// Before
pcsURL := pcs.generatePCSURL("file", "list", map[string]string{
    "path":  path,
    "by":    *(*string)(unsafe.Pointer(&options.By)),
    "order": *(*string)(unsafe.Pointer(&options.Order)),
    "limit": "0-2147483647",
})

// After
pcsURL := pcs.generatePCSURL("file", "list", map[string]string{
    "path":  path,
    "by":    *(*string)(unsafe.Pointer(&options.By)),
    "order": *(*string)(unsafe.Pointer(&options.Order)),
})
```

## Testing

Verified locally that after this change, both `ls` and `upload` commands work without 31023 errors.