### PR TITLE
fix: 修复批量下载时 DNS 解析导致 panic

### DIFF
--- a/internal/pcsfunctions/pcsdownload/download_task_unit.go
+++ b/internal/pcsfunctions/pcsdownload/download_task_unit.go
@@ -93,6 +93,14 @@ func (dtu *DownloadTaskUnit) verboseInfof(format string, a ...interface{}) {
 	}
 }
 
+// removeEmptyDownloadFile 删除 0 字节的残缺下载文件
+func removeEmptyDownloadFile(path string) {
+	info, statErr := os.Stat(path)
+	if statErr == nil && info.Size() == 0 {
+		_ = os.Remove(path)
+	}
+}
+
 // download 执行下载
 func (dtu *DownloadTaskUnit) download(downloadURL string, client *requester.HTTPClient) (err error) {
 	var (
@@ -101,6 +109,13 @@ func (dtu *DownloadTaskUnit) download(downloadURL string, client *requester.HTTP
 	)
 
 	if !dtu.Cfg.IsTest {
+		// panic 时清理空文件并转为可重试错误，避免整进程退出
+		defer func() {
+			if r := recover(); r != nil {
+				removeEmptyDownloadFile(dtu.SavePath)
+				err = fmt.Errorf("%s: panic: %v", StrDownloadFailed, r)
+			}
+		}()
 		// 非测试下载
 		dtu.Cfg.InstanceStatePath = dtu.SavePath + DownloadSuffix
 
@@ -200,14 +215,10 @@ func (dtu *DownloadTaskUnit) download(downloadURL string, client *requester.HTTP
 		// 下载发生错误
 		if !dtu.Cfg.IsTest {
 			// 下载失败, 删去空文件
-			if info, infoErr := file.Stat(); infoErr == nil {
-				if info.Size() == 0 {
-					// 空文件, 应该删除
-					dtu.verboseInfof("[%s] remove empty file: %s\n", dtu.taskInfo.Id(), dtu.SavePath)
-					removeErr := os.Remove(dtu.SavePath)
-					if removeErr != nil {
-						dtu.verboseInfof("[%s] remove file error: %s\n", dtu.taskInfo.Id(), removeErr)
-					}
+			if info, infoErr := file.Stat(); infoErr == nil && info.Size() == 0 {
+				dtu.verboseInfof("[%s] remove empty file: %s\n", dtu.taskInfo.Id(), dtu.SavePath)
+				if removeErr := os.Remove(dtu.SavePath); removeErr != nil {
+					dtu.verboseInfof("[%s] remove file error: %s\n", dtu.taskInfo.Id(), removeErr)
 				}
 			}
 		}

--- a/requester/dial.go
+++ b/requester/dial.go
@@ -4,14 +4,17 @@ import (
 	"context"
 	"crypto/tls"
 	"errors"
+	"fmt"
 	"github.com/qjfoidnh/BaiduPCS-Go/baidupcs/expires"
 	"github.com/qjfoidnh/BaiduPCS-Go/baidupcs/expires/cachemap"
+	"github.com/rs/dnscache"
 	mathrand "math/rand"
 	"net"
 	"net/http"
 	"net/url"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -33,6 +36,13 @@ var (
 	ErrProxyAddrEmpty = errors.New("proxy addr is empty")
 
 	tcpCache = cachemap.GlobalCacheOpMap.LazyInitCachePoolOp("requester/tcp")
+
+	// dnsResolver 通过 singleflight 合并同 host 查询；dnsLookupMu 串行化对标准库解析器的调用，
+	// 避免并发 Lookup 时在 tryOneName 路径触发 panic。
+	dnsResolver = &dnscache.Resolver{
+		Timeout: 30 * time.Second,
+	}
+	dnsLookupMu sync.Mutex
 )
 
 // SetLocalTCPAddrList 设置网卡地址
@@ -132,12 +142,33 @@ func getServerName(address string) string {
 // resolveTCPHost
 // 解析的tcpaddr没有port!!!
 func resolveTCPHost(ctx context.Context, host string) (ip net.IP, err error) {
-	addrs, err := net.DefaultResolver.LookupIPAddr(ctx, host)
-	if err != nil {
-		return
+	// host 已是字面量 IP 时直接返回，无需 DNS 查询
+	if parsed := net.ParseIP(host); parsed != nil {
+		return parsed, nil
 	}
 
-	return addrs[0].IP, nil
+	// 标准库 DNS 偶发 panic 时转为 error，避免进程崩溃
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("dns lookup panic for %q: %v", host, r)
+		}
+	}()
+
+	dnsLookupMu.Lock()
+	addrs, lookupErr := dnsResolver.LookupHost(ctx, host)
+	dnsLookupMu.Unlock()
+	if lookupErr != nil {
+		return nil, lookupErr
+	}
+	if len(addrs) == 0 {
+		return nil, fmt.Errorf("no IP addresses found for host %q", host)
+	}
+
+	ip = net.ParseIP(addrs[0])
+	if ip == nil {
+		return nil, fmt.Errorf("invalid IP address %q for host %q", addrs[0], host)
+	}
+	return ip, nil
 }
 
 func dialContext(ctx context.Context, network, address string) (conn net.Conn, err error) {


### PR DESCRIPTION
- 在 dial.go 中使用 dnscache 与互斥锁串行化 DNS 解析
- 下载路径增加 panic 恢复，并清理 0 字节残缺文件