### PR TITLE
fix: paginate directory listing to return all files beyond 1000

### DIFF
--- a/baidupcs/file_directory.go
+++ b/baidupcs/file_directory.go
@@ -155,28 +155,101 @@ func (pcs *BaiduPCS) FilesDirectoriesBatchMeta(paths ...string) (data FileDirect
 	return
 }
 
+// maxListNum 单次拉取目录列表的最大条目数, 网盘 web 列表接口每页上限为 1000
+const maxListNum = 1000
+
+// fdPanJSON 用于解析 pan.baidu.com/api/list 返回的目录条目
+// (字段命名与 PCS file/list 不同: 时间为 server_ctime/server_mtime, 无 app_id/ifhassubdir)
+type fdPanJSON struct {
+	FsID     int64  `json:"fs_id"`
+	AppID    int64  `json:"app_id"`
+	Path     string `json:"path"`
+	Filename string `json:"server_filename"`
+	Ctime    int64  `json:"server_ctime"`
+	Mtime    int64  `json:"server_mtime"`
+	MD5      string `json:"md5"`
+	BlockListJSON
+	Size           int64 `json:"size"`
+	IsdirInt       int8  `json:"isdir"`
+	IfhassubdirInt int8  `json:"ifhassubdir"`
+}
+
+// toFileDirectory 将 pan 接口条目转换为 FileDirectory
+func (j *fdPanJSON) toFileDirectory() *FileDirectory {
+	if j == nil {
+		return nil
+	}
+	return &FileDirectory{
+		FsID:          j.FsID,
+		AppID:         j.AppID,
+		Path:          j.Path,
+		Filename:      j.Filename,
+		Ctime:         j.Ctime,
+		Mtime:         j.Mtime,
+		MD5:           j.MD5,
+		BlockListJSON: j.BlockListJSON,
+		Size:          j.Size,
+		Isdir:         j.IsdirInt == 1,
+		Ifhassubdir:   j.IfhassubdirInt == 1,
+	}
+}
+
+// fdPanListJSON 用于解析 pan.baidu.com/api/list 的整体响应
+type fdPanListJSON struct {
+	*pcserror.PanErrorInfo
+	List []*fdPanJSON `json:"list"`
+}
+
 // FilesDirectoriesList 获取目录下的文件和目录列表
+//
+// 网盘 web 列表接口单页最多返回 1000 条, 这里按 page 循环分页拉取, 直至取完整个目录
+// (修复 https://github.com/qjfoidnh/BaiduPCS-Go/issues/511)。
+// 通过 fs_id 去重防御分页异常: 一旦出现重复条目立即终止, 避免死循环与重复数据。
 func (pcs *BaiduPCS) FilesDirectoriesList(path string, options *OrderOptions) (data FileDirectoryList, pcsError pcserror.Error) {
-	dataReadCloser, pcsError := pcs.PrepareFilesDirectoriesList(path, options)
-	if pcsError != nil {
-		return nil, pcsError
+	// 防御性上限, 避免接口异常导致死循环
+	const maxPage = 2000
+	seen := make(map[int64]struct{}, maxListNum)
+
+	for page := 1; page <= maxPage; page++ {
+		dataReadCloser, err := pcs.PrepareFilesDirectoriesList(path, options, maxListNum, page)
+		if err != nil {
+			pcsError = err
+			return
+		}
+
+		jsonData := fdPanListJSON{
+			PanErrorInfo: pcserror.NewPanErrorInfo(OperationFilesDirectoriesList),
+		}
+
+		err = pcserror.HandleJSONParse(OperationFilesDirectoriesList, dataReadCloser, &jsonData)
+		dataReadCloser.Close()
+		if err != nil {
+			pcsError = err
+			return
+		}
+
+		if len(jsonData.List) == 0 {
+			break
+		}
+
+		// 转换为 FileDirectory 并按 fs_id 去重
+		pageList := make(FileDirectoryList, 0, len(jsonData.List))
+		for _, j := range jsonData.List {
+			if _, ok := seen[j.FsID]; ok {
+				// 重复 fs_id 说明分页未继续推进 (或已绕回), 终止遍历
+				return
+			}
+			seen[j.FsID] = struct{}{}
+			pageList = append(pageList, j.toFileDirectory())
+		}
+		// 修复MD5
+		pageList.fixMD5()
+		data = append(data, pageList...)
+
+		if len(jsonData.List) < maxListNum {
+			break // 已取完最后一页
+		}
 	}
-
-	defer dataReadCloser.Close()
-
-	jsonData := fdData{
-		PCSErrInfo: pcserror.NewPCSErrorInfo(OperationFilesDirectoriesList),
-	}
-
-	pcsError = pcserror.HandleJSONParse(OperationFilesDirectoriesList, dataReadCloser, (*fdDataJSONExport)(unsafe.Pointer(&jsonData)))
-	if pcsError != nil {
-		return nil, pcsError
-	}
-
-	// 修复MD5
-	jsonData.List.fixMD5()
-
-	data = jsonData.List
 	return
 }
 

--- a/baidupcs/prepare.go
+++ b/baidupcs/prepare.go
@@ -8,7 +8,6 @@ import (
 	"path"
 	"strconv"
 	"strings"
-	"unsafe"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/qjfoidnh/BaiduPCS-Go/baidupcs/netdisksign"
@@ -159,7 +158,12 @@ func (pcs *BaiduPCS) PrepareFilesDirectoriesBatchMeta(paths ...string) (dataRead
 }
 
 // PrepareFilesDirectoriesList 获取目录下的文件和目录列表, 只返回服务器响应数据和错误信息
-func (pcs *BaiduPCS) PrepareFilesDirectoriesList(path string, options *OrderOptions) (dataReadCloser io.ReadCloser, pcsError pcserror.Error) {
+//
+// 走 pan.baidu.com/api/list 接口: PCS 的 file/list 单次最多返回 1000 条且 num/page 参数被忽略
+// (limit/start 则直接报 param error), 无法获取超过 1000 条的目录; 网盘 web 列表接口支持
+// num/page 翻页, 修复 https://github.com/qjfoidnh/BaiduPCS-Go/issues/511。
+// num: 每页条目数 (<=0 或 >1000 时取 1000); page: 页码 (从 1 开始)
+func (pcs *BaiduPCS) PrepareFilesDirectoriesList(path string, options *OrderOptions, num, page int) (dataReadCloser io.ReadCloser, pcsError pcserror.Error) {
 	pcs.lazyInit()
 	if options == nil {
 		options = DefaultOrderOptions
@@ -167,15 +171,29 @@ func (pcs *BaiduPCS) PrepareFilesDirectoriesList(path string, options *OrderOpti
 	if path == "" {
 		path = PathSeparator
 	}
+	if num <= 0 || num > maxListNum {
+		num = maxListNum
+	}
+	if page <= 0 {
+		page = 1
+	}
 
-	pcsURL := pcs.generatePCSURL("file", "list", map[string]string{
-		"path":  path,
-		"by":    *(*string)(unsafe.Pointer(&options.By)),
-		"order": *(*string)(unsafe.Pointer(&options.Order)),
+	// pan 的排序参数: order 取 name/time/size (与 OrderBy 常量一致), desc 为 0/1
+	desc := "0"
+	if options.Order == OrderDesc {
+		desc = "1"
+	}
+	panURL := pcs.generatePanURL("list", map[string]string{
+		"dir":        path,
+		"order":      string(options.By),
+		"desc":       desc,
+		"clienttype": "0",
+		"num":        strconv.Itoa(num),
+		"page":       strconv.Itoa(page),
 	})
-	baiduPCSVerbose.Infof("%s URL: %s\n", OperationFilesDirectoriesList, pcsURL)
+	baiduPCSVerbose.Infof("%s URL: %s\n", OperationFilesDirectoriesList, panURL)
 
-	dataReadCloser, pcsError = pcs.sendReqReturnReadCloser(reqTypePCS, OperationFilesDirectoriesList, http.MethodGet, pcsURL.String(), nil, nil)
+	dataReadCloser, pcsError = pcs.sendReqReturnReadCloser(reqTypePan, OperationFilesDirectoriesList, http.MethodGet, panURL.String(), nil, nil)
 	return
 }
 


### PR DESCRIPTION
The PCS file/list endpoint cannot paginate (num/page are ignored, limit/start return a param error), so ls, download, tree and export were capped at 1000 entries per folder. Switch FilesDirectoriesList to pan.baidu.com/api/list, which honors num/page, looping pages until the directory is exhausted. An fs_id dedup guard fails safe if the server ever repeats entries.

Fixes #511