### PR TITLE
feat: 增加基于 cgofuse 的只读网盘挂载功能

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ iikira/BaiduPCS-Go was largely inspired by [GangZhuo/BaiduPCS](https://github.co
 - [特色](#特色)
 - [版本更新](#版本更新)
 - [编译/交叉编译 说明](#编译交叉编译-说明)
+  * [挂载功能编译说明](#挂载功能编译说明)
 - [下载/运行 说明](#下载运行-说明)
   * [安装](#安装)
   * [Windows](#windows)
@@ -298,6 +299,32 @@ set CGO_ENABLED=0
 go build
 ```
 
+## 挂载功能编译说明
+
+挂载功能基于 [winfsp/cgofuse](https://github.com/winfsp/cgofuse), 不同平台需要安装对应的 FUSE 实现.
+
+* Windows: 安装 [WinFsp](https://winfsp.dev/), 支持 `CGO_ENABLED=0` 编译.
+* macOS: 安装 [macFUSE](https://macfuse.github.io/), 使用 `CGO_ENABLED=1` 编译.
+* Linux: 安装 FUSE 或 FUSE3 开发库和 C 编译器, 使用 `CGO_ENABLED=1` 编译.
+
+Windows 编译示例:
+```
+set CGO_ENABLED=0
+go build
+```
+
+Linux/macOS 使用 FUSE2 编译:
+```
+CGO_ENABLED=1 go build
+```
+
+Linux 使用 FUSE3 编译:
+```
+CGO_ENABLED=1 go build -tags=fuse3
+```
+
+> Linux 和 macOS 使用 `CGO_ENABLED=0` 编译时仍可使用其他 CLI 功能, 但运行 `mount` 命令会提示重新启用 CGO 编译.
+
 # 下载/运行 说明
 
 Go语言程序, 常用几种平台的已编译程序可直接在[蓝奏云](https://wws.lanzoui.com/b01berebe)下载使用. 密码:4pix
@@ -556,29 +583,55 @@ BaiduPCS-Go search -r 关键字
 
 ## 挂载百度网盘
 
-第一阶段挂载功能为只读模式，支持浏览目录、查看文件属性，以及通过 HTTP Range 按需读取文件。
-
-运行前需要安装对应平台的 FUSE 实现：Windows 使用 WinFsp，macOS 使用 macFUSE，Linux 使用 FUSE。Linux 和 macOS 构建挂载功能时需要启用 CGO。
-
-```shell
-# Windows：将网盘根目录挂载为 X 盘
-BaiduPCS-Go mount X:
-
-# Linux/macOS：挂载到本地目录
-BaiduPCS-Go mount /mnt/baidupan
-
-# 仅挂载指定的网盘目录
-BaiduPCS-Go mount /mnt/baidupan --path /我的资源
+```
+BaiduPCS-Go mount <本地挂载点>
+BaiduPCS-Go mnt <本地挂载点>
 ```
 
-可用参数：
+将当前帐号的百度网盘挂载到本地文件系统, 支持浏览目录、查看文件属性和读取文件.
 
-```text
-  --path value       作为挂载根目录的百度网盘目录 (default: "/")
-  --cache-ttl value  目录和元信息缓存时间 (default: 30s)
-  --debug            启用 FUSE 调试输出
-  --single-thread    让 FUSE 串行处理文件系统请求
-  -o value           传递给 FUSE 的额外挂载选项，可重复指定
+文件读取采用 HTTP Range 按需请求, 打开大文件时不会预先将整个文件下载到本地. 目录列表、文件元信息和下载链接会在内存中缓存一段时间, 以减少百度网盘 API 请求.
+
+当前挂载功能为只读模式, 不支持新建、写入、上传、删除和重命名文件或目录. 应用程序尝试修改挂载盘内容时会收到只读文件系统错误.
+
+运行前需完成以下准备:
+
+* 登录百度帐号, 并确认 `BaiduPCS-Go ls /` 可以正常列出文件.
+* Windows 安装 WinFsp, macOS 安装 macFUSE, Linux 安装 FUSE/FUSE3.
+* Linux 和 macOS 版本需在启用 CGO 的环境下编译.
+
+### 可选参数
+```
+--path value:      作为挂载根目录的百度网盘目录, 默认为 /
+--cache-ttl value: 目录和元信息缓存时间, 默认为 30s
+--debug:           启用 FUSE 调试输出
+--single-thread:   让 FUSE 串行处理文件系统请求
+-o value:          传递给 FUSE 的额外挂载选项, 可重复指定
+```
+
+#### 例子
+```
+# Windows: 将网盘根目录挂载为 X 盘
+BaiduPCS-Go mount X:
+
+# Windows: 将 /我的资源 挂载为 X 盘
+BaiduPCS-Go mount --path /我的资源 X:
+
+# Linux/macOS: 将网盘根目录挂载到本地目录
+BaiduPCS-Go mount /mnt/baidupan
+
+# Linux/macOS: 挂载指定的网盘目录, 并缩短目录缓存时间
+BaiduPCS-Go mount --path /我的资源 --cache-ttl 10s /mnt/baidupan
+
+# 启用程序和 FUSE 调试输出
+BaiduPCS-Go --verbose mount --debug X:
+```
+
+挂载命令会持续占用当前终端. 正常卸载时, 请在运行挂载命令的终端按 `Ctrl+C`.
+
+Linux 使用 FUSE3 时, 如果程序异常退出后挂载点仍然存在, 可手动卸载:
+```
+fusermount3 -u /mnt/baidupan
 ```
 
 ## 下载文件/目录

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ iikira/BaiduPCS-Go was largely inspired by [GangZhuo/BaiduPCS](https://github.co
   * [列出目录树形图](#列出目录树形图)
   * [获取文件/目录的元信息](#获取文件目录的元信息)
   * [搜索文件](#搜索文件)
+  * [挂载百度网盘](#挂载百度网盘)
   * [下载文件/目录](#下载文件目录)
   * [上传文件/目录](#上传文件目录)
   * [获取下载直链](#获取下载直链)
@@ -551,6 +552,33 @@ BaiduPCS-Go search 关键字
 
 # 递归搜索当前工作目录的文件
 BaiduPCS-Go search -r 关键字
+```
+
+## 挂载百度网盘
+
+第一阶段挂载功能为只读模式，支持浏览目录、查看文件属性，以及通过 HTTP Range 按需读取文件。
+
+运行前需要安装对应平台的 FUSE 实现：Windows 使用 WinFsp，macOS 使用 macFUSE，Linux 使用 FUSE。Linux 和 macOS 构建挂载功能时需要启用 CGO。
+
+```shell
+# Windows：将网盘根目录挂载为 X 盘
+BaiduPCS-Go mount X:
+
+# Linux/macOS：挂载到本地目录
+BaiduPCS-Go mount /mnt/baidupan
+
+# 仅挂载指定的网盘目录
+BaiduPCS-Go mount /mnt/baidupan --path /我的资源
+```
+
+可用参数：
+
+```text
+  --path value       作为挂载根目录的百度网盘目录 (default: "/")
+  --cache-ttl value  目录和元信息缓存时间 (default: 30s)
+  --debug            启用 FUSE 调试输出
+  --single-thread    让 FUSE 串行处理文件系统请求
+  -o value           传递给 FUSE 的额外挂载选项，可重复指定
 ```
 
 ## 下载文件/目录

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/qjfoidnh/baidu-tools v1.2.0 //dfa5778abeed
 	github.com/tidwall/gjson v1.18.0
 	github.com/urfave/cli v1.22.5
+	github.com/winfsp/cgofuse v1.6.0
 	golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550
 	golang.org/x/sys v0.25.0
 )

--- a/go.sum
+++ b/go.sum
@@ -203,6 +203,8 @@ github.com/urfave/cli v1.22.5/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtX
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/fasttemplate v1.0.1/go.mod h1:UQGH1tvbgY+Nz5t2n7tXsz52dQxojPUpymEIMZ47gx8=
 github.com/wendal/errors v0.0.0-20130201093226-f66c77a7882b/go.mod h1:Q12BUT7DqIlHRmgv3RskH+UCM/4eqVMgI0EMmlSpAXc=
+github.com/winfsp/cgofuse v1.6.0 h1:re3W+HTd0hj4fISPBqfsrwyvPFpzqhDu8doJ9nOPDB0=
+github.com/winfsp/cgofuse v1.6.0/go.mod h1:uxjoF2jEYT3+x+vC2KJddEGdk/LU8pRowXmyVMHSV5I=
 github.com/yuin/gopher-lua v0.0.0-20171031051903-609c9cd26973/go.mod h1:aEV29XrmTYFr3CiRxZeGHpkvbwq+prZduBqMaascyCU=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=

--- a/internal/pcsmount/filesystem.go
+++ b/internal/pcsmount/filesystem.go
@@ -1,0 +1,395 @@
+//go:build windows || cgo
+
+// Package pcsmount exposes a Baidu PCS directory through FUSE.
+package pcsmount
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"path"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/qjfoidnh/BaiduPCS-Go/baidupcs"
+	"github.com/qjfoidnh/BaiduPCS-Go/internal/pcsconfig"
+	"github.com/qjfoidnh/BaiduPCS-Go/internal/pcsfunctions/pcsdownload"
+	"github.com/qjfoidnh/BaiduPCS-Go/pcsverbose"
+	"github.com/winfsp/cgofuse/fuse"
+)
+
+const (
+	defaultCacheTTL = 30 * time.Second
+	linkCacheTTL    = 5 * time.Minute
+	blockSize       = 4096
+)
+
+var mountVerbose = pcsverbose.New("PCSMOUNT")
+
+type metadataCacheEntry struct {
+	value     *baidupcs.FileDirectory
+	expiresAt time.Time
+}
+
+type directoryCacheEntry struct {
+	value     baidupcs.FileDirectoryList
+	expiresAt time.Time
+}
+
+type linkCacheEntry struct {
+	value     string
+	expiresAt time.Time
+}
+
+// FileSystem is a read-only view of a Baidu PCS directory.
+type FileSystem struct {
+	fuse.FileSystemBase
+
+	pcs      *baidupcs.BaiduPCS
+	root     string
+	cacheTTL time.Duration
+
+	mu          sync.RWMutex
+	metadata    map[string]metadataCacheEntry
+	directories map[string]directoryCacheEntry
+	links       map[string]linkCacheEntry
+	quota       int64
+	used        int64
+	quotaExpiry time.Time
+}
+
+// NewFileSystem validates remoteRoot and creates a read-only file system.
+func NewFileSystem(pcs *baidupcs.BaiduPCS, remoteRoot string, cacheTTL time.Duration) (*FileSystem, error) {
+	if pcs == nil {
+		return nil, errors.New("BaiduPCS client is nil")
+	}
+	remoteRoot = cleanRemotePath(remoteRoot)
+	if cacheTTL <= 0 {
+		cacheTTL = defaultCacheTTL
+	}
+
+	rootInfo, pcsErr := pcs.FilesDirectoriesMeta(remoteRoot)
+	if pcsErr != nil {
+		return nil, fmt.Errorf("读取挂载目录元信息失败: %w", pcsErr)
+	}
+	if !rootInfo.Isdir {
+		return nil, fmt.Errorf("挂载源不是目录: %s", remoteRoot)
+	}
+
+	fs := &FileSystem{
+		pcs:         pcs,
+		root:        remoteRoot,
+		cacheTTL:    cacheTTL,
+		metadata:    make(map[string]metadataCacheEntry),
+		directories: make(map[string]directoryCacheEntry),
+		links:       make(map[string]linkCacheEntry),
+	}
+	fs.metadata[remoteRoot] = metadataCacheEntry{value: rootInfo, expiresAt: time.Now().Add(cacheTTL)}
+	return fs, nil
+}
+
+func cleanRemotePath(value string) string {
+	value = strings.ReplaceAll(value, "\\", "/")
+	if value == "" {
+		return "/"
+	}
+	if !strings.HasPrefix(value, "/") {
+		value = "/" + value
+	}
+	return path.Clean(value)
+}
+
+func (fs *FileSystem) remotePath(fusePath string) string {
+	if fusePath == "" || fusePath == "/" {
+		return fs.root
+	}
+	return path.Join(fs.root, strings.TrimPrefix(cleanRemotePath(fusePath), "/"))
+}
+
+func (fs *FileSystem) getMetadata(fusePath string) (*baidupcs.FileDirectory, error) {
+	remotePath := fs.remotePath(fusePath)
+	now := time.Now()
+	fs.mu.RLock()
+	entry, ok := fs.metadata[remotePath]
+	fs.mu.RUnlock()
+	if ok && now.Before(entry.expiresAt) {
+		return entry.value, nil
+	}
+
+	value, pcsErr := fs.pcs.FilesDirectoriesMeta(remotePath)
+	if pcsErr != nil {
+		return nil, pcsErr
+	}
+	fs.mu.Lock()
+	fs.metadata[remotePath] = metadataCacheEntry{value: value, expiresAt: now.Add(fs.cacheTTL)}
+	fs.mu.Unlock()
+	return value, nil
+}
+
+func (fs *FileSystem) getDirectory(fusePath string) (baidupcs.FileDirectoryList, error) {
+	remotePath := fs.remotePath(fusePath)
+	now := time.Now()
+	fs.mu.RLock()
+	entry, ok := fs.directories[remotePath]
+	fs.mu.RUnlock()
+	if ok && now.Before(entry.expiresAt) {
+		return entry.value, nil
+	}
+
+	value, pcsErr := fs.pcs.FilesDirectoriesList(remotePath, baidupcs.DefaultOrderOptions)
+	if pcsErr != nil {
+		return nil, pcsErr
+	}
+	fs.mu.Lock()
+	fs.directories[remotePath] = directoryCacheEntry{value: value, expiresAt: now.Add(fs.cacheTTL)}
+	for _, child := range value {
+		fs.metadata[child.Path] = metadataCacheEntry{value: child, expiresAt: now.Add(fs.cacheTTL)}
+	}
+	fs.mu.Unlock()
+	return value, nil
+}
+
+func fillStat(info *baidupcs.FileDirectory, stat *fuse.Stat_t) {
+	stat.Ino = uint64(info.FsID)
+	stat.Nlink = 1
+	stat.Size = info.Size
+	stat.Blksize = blockSize
+	stat.Blocks = (info.Size + 511) / 512
+	stat.Atim = fuse.NewTimespec(time.Unix(info.Mtime, 0))
+	stat.Mtim = fuse.NewTimespec(time.Unix(info.Mtime, 0))
+	stat.Ctim = fuse.NewTimespec(time.Unix(info.Ctime, 0))
+	stat.Birthtim = stat.Ctim
+	if info.Isdir {
+		stat.Mode = fuse.S_IFDIR | 0555
+		stat.Nlink = 2
+	} else {
+		stat.Mode = fuse.S_IFREG | 0444
+	}
+}
+
+func (fs *FileSystem) Getattr(fusePath string, stat *fuse.Stat_t, _ uint64) int {
+	info, err := fs.getMetadata(fusePath)
+	if err != nil {
+		mountVerbose.Warnf("getattr %s: %s\n", fusePath, err)
+		return -fuse.ENOENT
+	}
+	fillStat(info, stat)
+	return 0
+}
+
+func (fs *FileSystem) Access(fusePath string, mask uint32) int {
+	if mask&(fuse.W_OK|fuse.DELETE_OK) != 0 {
+		return -fuse.EROFS
+	}
+	if _, err := fs.getMetadata(fusePath); err != nil {
+		return -fuse.ENOENT
+	}
+	return 0
+}
+
+func (fs *FileSystem) Open(fusePath string, flags int) (int, uint64) {
+	if flags&fuse.O_ACCMODE != fuse.O_RDONLY || flags&fuse.O_TRUNC != 0 {
+		return -fuse.EROFS, ^uint64(0)
+	}
+	info, err := fs.getMetadata(fusePath)
+	if err != nil {
+		return -fuse.ENOENT, ^uint64(0)
+	}
+	if info.Isdir {
+		return -fuse.EISDIR, ^uint64(0)
+	}
+	return 0, uint64(info.FsID)
+}
+
+func (fs *FileSystem) Opendir(fusePath string) (int, uint64) {
+	info, err := fs.getMetadata(fusePath)
+	if err != nil {
+		return -fuse.ENOENT, ^uint64(0)
+	}
+	if !info.Isdir {
+		return -fuse.ENOTDIR, ^uint64(0)
+	}
+	return 0, uint64(info.FsID)
+}
+
+func (fs *FileSystem) Readdir(fusePath string, fill func(string, *fuse.Stat_t, int64) bool, ofst int64, _ uint64) int {
+	children, err := fs.getDirectory(fusePath)
+	if err != nil {
+		mountVerbose.Warnf("readdir %s: %s\n", fusePath, err)
+		return -fuse.EIO
+	}
+
+	type item struct {
+		name string
+		info *baidupcs.FileDirectory
+	}
+	items := make([]item, 0, len(children)+2)
+	items = append(items, item{name: "."}, item{name: ".."})
+	for _, child := range children {
+		items = append(items, item{name: child.Filename, info: child})
+	}
+	if ofst < 0 || ofst > int64(len(items)) {
+		return -fuse.EINVAL
+	}
+	for index := int(ofst); index < len(items); index++ {
+		var stat *fuse.Stat_t
+		if items[index].info != nil {
+			stat = &fuse.Stat_t{}
+			fillStat(items[index].info, stat)
+		}
+		if !fill(items[index].name, stat, int64(index+1)) {
+			break
+		}
+	}
+	return 0
+}
+
+func (fs *FileSystem) downloadLink(remotePath string, refresh bool) (string, error) {
+	now := time.Now()
+	if !refresh {
+		fs.mu.RLock()
+		entry, ok := fs.links[remotePath]
+		fs.mu.RUnlock()
+		if ok && now.Before(entry.expiresAt) {
+			return entry.value, nil
+		}
+	}
+
+	links, err := pcsdownload.GetLocateDownloadLinks(fs.pcs, remotePath)
+	if err != nil {
+		return "", err
+	}
+	if len(links) == 0 {
+		return "", errors.New("百度网盘未返回下载链接")
+	}
+	pcsdownload.FixHTTPLinkURL(links[0])
+	value := links[0].String()
+	fs.mu.Lock()
+	fs.links[remotePath] = linkCacheEntry{value: value, expiresAt: now.Add(linkCacheTTL)}
+	fs.mu.Unlock()
+	return value, nil
+}
+
+func (fs *FileSystem) readRange(remotePath string, buff []byte, offset int64) (int, error) {
+	if len(buff) == 0 {
+		return 0, nil
+	}
+	for attempt := 0; attempt < 2; attempt++ {
+		link, err := fs.downloadLink(remotePath, attempt > 0)
+		if err != nil {
+			return 0, err
+		}
+		client := pcsconfig.Config.PanHTTPClient()
+		client.SetTimeout(2 * time.Minute)
+		jar, err := pcsdownload.CloneJarWithDomain(fs.pcs.GetClient().Jar, link)
+		if err != nil {
+			return 0, err
+		}
+		client.SetCookiejar(jar)
+		end := offset + int64(len(buff)) - 1
+		resp, err := client.Req(http.MethodGet, link, nil, map[string]string{
+			"Range": fmt.Sprintf("bytes=%d-%d", offset, end),
+		})
+		if resp != nil {
+			defer resp.Body.Close()
+		}
+		if err != nil {
+			if attempt == 0 {
+				continue
+			}
+			return 0, err
+		}
+		if resp.StatusCode == http.StatusRequestedRangeNotSatisfiable {
+			return 0, nil
+		}
+		if resp.StatusCode != http.StatusPartialContent && !(offset == 0 && resp.StatusCode == http.StatusOK) {
+			if attempt == 0 && (resp.StatusCode == http.StatusForbidden || resp.StatusCode == http.StatusUnauthorized) {
+				continue
+			}
+			return 0, fmt.Errorf("下载请求返回 %s", resp.Status)
+		}
+		n, readErr := io.ReadFull(resp.Body, buff)
+		if readErr == io.EOF || readErr == io.ErrUnexpectedEOF {
+			return n, nil
+		}
+		return n, readErr
+	}
+	return 0, errors.New("下载链接刷新后仍不可用")
+}
+
+func (fs *FileSystem) Read(fusePath string, buff []byte, offset int64, _ uint64) int {
+	if offset < 0 {
+		return -fuse.EINVAL
+	}
+	info, err := fs.getMetadata(fusePath)
+	if err != nil {
+		return -fuse.ENOENT
+	}
+	if info.Isdir {
+		return -fuse.EISDIR
+	}
+	if offset >= info.Size {
+		return 0
+	}
+	if remaining := info.Size - offset; int64(len(buff)) > remaining {
+		buff = buff[:remaining]
+	}
+	n, err := fs.readRange(fs.remotePath(fusePath), buff, offset)
+	if err != nil {
+		mountVerbose.Warnf("read %s at %d: %s\n", fusePath, offset, err)
+		return -fuse.EIO
+	}
+	return n
+}
+
+func (fs *FileSystem) Statfs(_ string, stat *fuse.Statfs_t) int {
+	now := time.Now()
+	fs.mu.RLock()
+	quota, used, valid := fs.quota, fs.used, now.Before(fs.quotaExpiry)
+	fs.mu.RUnlock()
+	if !valid {
+		var pcsErr error
+		quota, used, pcsErr = fs.pcs.QuotaInfo()
+		if pcsErr != nil {
+			return -fuse.EIO
+		}
+		fs.mu.Lock()
+		fs.quota, fs.used, fs.quotaExpiry = quota, used, now.Add(fs.cacheTTL)
+		fs.mu.Unlock()
+	}
+	free := quota - used
+	if free < 0 {
+		free = 0
+	}
+	stat.Bsize = blockSize
+	stat.Frsize = blockSize
+	stat.Blocks = uint64(quota / blockSize)
+	stat.Bfree = uint64(free / blockSize)
+	stat.Bavail = stat.Bfree
+	stat.Namemax = 255
+	return 0
+}
+
+func (fs *FileSystem) Release(string, uint64) int        { return 0 }
+func (fs *FileSystem) Releasedir(string, uint64) int     { return 0 }
+func (fs *FileSystem) Flush(string, uint64) int          { return 0 }
+func (fs *FileSystem) Fsync(string, bool, uint64) int    { return 0 }
+func (fs *FileSystem) Fsyncdir(string, bool, uint64) int { return 0 }
+
+func (fs *FileSystem) Mknod(string, uint32, uint64) int         { return -fuse.EROFS }
+func (fs *FileSystem) Mkdir(string, uint32) int                 { return -fuse.EROFS }
+func (fs *FileSystem) Unlink(string) int                        { return -fuse.EROFS }
+func (fs *FileSystem) Rmdir(string) int                         { return -fuse.EROFS }
+func (fs *FileSystem) Link(string, string) int                  { return -fuse.EROFS }
+func (fs *FileSystem) Symlink(string, string) int               { return -fuse.EROFS }
+func (fs *FileSystem) Rename(string, string) int                { return -fuse.EROFS }
+func (fs *FileSystem) Chmod(string, uint32) int                 { return -fuse.EROFS }
+func (fs *FileSystem) Chown(string, uint32, uint32) int         { return -fuse.EROFS }
+func (fs *FileSystem) Utimens(string, []fuse.Timespec) int      { return -fuse.EROFS }
+func (fs *FileSystem) Create(string, int, uint32) (int, uint64) { return -fuse.EROFS, ^uint64(0) }
+func (fs *FileSystem) Truncate(string, int64, uint64) int       { return -fuse.EROFS }
+func (fs *FileSystem) Write(string, []byte, int64, uint64) int  { return -fuse.EROFS }
+func (fs *FileSystem) Setxattr(string, string, []byte, int) int { return -fuse.EROFS }
+func (fs *FileSystem) Removexattr(string, string) int           { return -fuse.EROFS }

--- a/internal/pcsmount/filesystem_test.go
+++ b/internal/pcsmount/filesystem_test.go
@@ -1,0 +1,49 @@
+//go:build windows || cgo
+
+package pcsmount
+
+import (
+	"testing"
+
+	"github.com/qjfoidnh/BaiduPCS-Go/baidupcs"
+	"github.com/winfsp/cgofuse/fuse"
+)
+
+func TestCleanRemotePath(t *testing.T) {
+	tests := map[string]string{
+		"":               "/",
+		"/":              "/",
+		"我的资源":           "/我的资源",
+		`\我的资源\视频\..\文档`: "/我的资源/文档",
+		"/a/../../b":     "/b",
+	}
+	for input, want := range tests {
+		if got := cleanRemotePath(input); got != want {
+			t.Errorf("cleanRemotePath(%q) = %q, want %q", input, got, want)
+		}
+	}
+}
+
+func TestRemotePathStaysUnderMountRoot(t *testing.T) {
+	fs := &FileSystem{root: "/我的资源"}
+	if got, want := fs.remotePath("/视频/a.mp4"), "/我的资源/视频/a.mp4"; got != want {
+		t.Fatalf("remotePath() = %q, want %q", got, want)
+	}
+	if got, want := fs.remotePath("/../../文档"), "/我的资源/文档"; got != want {
+		t.Fatalf("remotePath() traversal result = %q, want %q", got, want)
+	}
+}
+
+func TestFillStatReadOnlyModes(t *testing.T) {
+	fileStat := &fuse.Stat_t{}
+	fillStat(&baidupcs.FileDirectory{FsID: 7, Size: 513}, fileStat)
+	if fileStat.Mode != fuse.S_IFREG|0444 || fileStat.Blocks != 2 {
+		t.Fatalf("unexpected file stat: mode=%o blocks=%d", fileStat.Mode, fileStat.Blocks)
+	}
+
+	dirStat := &fuse.Stat_t{}
+	fillStat(&baidupcs.FileDirectory{FsID: 8, Isdir: true}, dirStat)
+	if dirStat.Mode != fuse.S_IFDIR|0555 || dirStat.Nlink != 2 {
+		t.Fatalf("unexpected directory stat: mode=%o nlink=%d", dirStat.Mode, dirStat.Nlink)
+	}
+}

--- a/internal/pcsmount/mount.go
+++ b/internal/pcsmount/mount.go
@@ -1,0 +1,51 @@
+//go:build windows || cgo
+
+package pcsmount
+
+import (
+	"fmt"
+
+	"github.com/qjfoidnh/BaiduPCS-Go/baidupcs"
+	"github.com/winfsp/cgofuse/fuse"
+)
+
+// Mount blocks until the file system is unmounted.
+func Mount(pcs *baidupcs.BaiduPCS, mountpoint string, options *Options) (err error) {
+	if mountpoint == "" {
+		return fmt.Errorf("挂载点不能为空")
+	}
+	if options == nil {
+		options = &Options{}
+	}
+	fs, err := NewFileSystem(pcs, options.RemoteRoot, options.CacheTTL)
+	if err != nil {
+		return err
+	}
+
+	host := fuse.NewFileSystemHost(fs)
+	host.SetCapReaddirPlus(true)
+	host.SetUseIno(true)
+
+	args := []string{"-o", "ro"}
+	if options.Debug {
+		args = append(args, "-d")
+	}
+	if options.SingleThread {
+		args = append(args, "-s")
+	}
+	for _, option := range options.FuseOptions {
+		if option != "" {
+			args = append(args, "-o", option)
+		}
+	}
+
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			err = fmt.Errorf("启动 FUSE 失败: %v", recovered)
+		}
+	}()
+	if !host.Mount(mountpoint, args) {
+		return fmt.Errorf("FUSE 挂载失败")
+	}
+	return nil
+}

--- a/internal/pcsmount/mount_stub.go
+++ b/internal/pcsmount/mount_stub.go
@@ -1,0 +1,14 @@
+//go:build !windows && !cgo
+
+package pcsmount
+
+import (
+	"errors"
+
+	"github.com/qjfoidnh/BaiduPCS-Go/baidupcs"
+)
+
+// Mount reports why a Unix build without cgo cannot host FUSE.
+func Mount(_ *baidupcs.BaiduPCS, _ string, _ *Options) error {
+	return errors.New("当前程序未启用挂载支持；Linux/macOS 需要安装 FUSE 开发库并使用 CGO_ENABLED=1 重新编译")
+}

--- a/internal/pcsmount/options.go
+++ b/internal/pcsmount/options.go
@@ -1,0 +1,12 @@
+package pcsmount
+
+import "time"
+
+// Options controls a mount session.
+type Options struct {
+	RemoteRoot   string
+	CacheTTL     time.Duration
+	Debug        bool
+	SingleThread bool
+	FuseOptions  []string
+}

--- a/main.go
+++ b/main.go
@@ -11,6 +11,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 	"unicode"
 
 	"github.com/olekukonko/tablewriter"
@@ -20,6 +21,7 @@ import (
 	"github.com/qjfoidnh/BaiduPCS-Go/internal/pcsconfig"
 	"github.com/qjfoidnh/BaiduPCS-Go/internal/pcsfunctions/pcsdownload"
 	_ "github.com/qjfoidnh/BaiduPCS-Go/internal/pcsinit"
+	"github.com/qjfoidnh/BaiduPCS-Go/internal/pcsmount"
 	"github.com/qjfoidnh/BaiduPCS-Go/internal/pcsupdate"
 	"github.com/qjfoidnh/BaiduPCS-Go/pcsliner"
 	"github.com/qjfoidnh/BaiduPCS-Go/pcsliner/args"
@@ -1016,6 +1018,70 @@ func main() {
 
 				pcscommand.RunMove(c.Args()...)
 				return nil
+			},
+		},
+		{
+			Name:      "mount",
+			Aliases:   []string{"mnt"},
+			Usage:     "将百度网盘目录只读挂载到本地文件系统",
+			UsageText: app.Name + " mount <本地挂载点> [--path <网盘目录>]",
+			Description: `
+	第一阶段挂载功能为只读模式, 支持浏览目录、查看文件属性和按需读取文件.
+	Windows 需要安装 WinFsp; macOS 需要安装 macFUSE; Linux 需要安装 FUSE.
+
+	示例:
+		BaiduPCS-Go mount X:
+		BaiduPCS-Go mount /mnt/baidupan --path /我的资源
+`,
+			Category: "百度网盘",
+			Before:   reloadFn,
+			Action: func(c *cli.Context) error {
+				if c.NArg() != 1 {
+					cli.ShowCommandHelp(c, c.Command.Name)
+					return nil
+				}
+				fuseOptions := []string{}
+				for _, value := range c.StringSlice("o") {
+					fuseOptions = append(fuseOptions, value)
+				}
+				fmt.Printf("正在将网盘目录 %s 挂载到 %s，按 Ctrl+C 可卸载...\n", c.String("path"), c.Args().Get(0))
+				err := pcsmount.Mount(pcsconfig.Config.ActiveUserBaiduPCS(), c.Args().Get(0), &pcsmount.Options{
+					RemoteRoot:   c.String("path"),
+					CacheTTL:     c.Duration("cache-ttl"),
+					Debug:        c.Bool("debug"),
+					SingleThread: c.Bool("single-thread"),
+					FuseOptions:  fuseOptions,
+				})
+				if err != nil {
+					fmt.Printf("挂载失败: %s\n", err)
+					return nil
+				}
+				fmt.Println("网盘已卸载")
+				return nil
+			},
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name:  "path",
+					Usage: "作为挂载根目录的百度网盘目录",
+					Value: "/",
+				},
+				cli.DurationFlag{
+					Name:  "cache-ttl",
+					Usage: "目录和元信息缓存时间",
+					Value: 30 * time.Second,
+				},
+				cli.BoolFlag{
+					Name:  "debug",
+					Usage: "启用 FUSE 调试输出",
+				},
+				cli.BoolFlag{
+					Name:  "single-thread",
+					Usage: "让 FUSE 串行处理文件系统请求",
+				},
+				cli.StringSliceFlag{
+					Name:  "o",
+					Usage: "传递给 FUSE 的额外挂载选项，可重复指定",
+				},
 			},
 		},
 		{


### PR DESCRIPTION
## 功能说明

增加基于 [winfsp/cgofuse](https://github.com/winfsp/cgofuse) 的跨平台文件系统挂载功能，可通过 `mount` 命令将百度网盘目录只读挂载到本地。

```shell
# Windows
BaiduPCS-Go mount X:

# Linux/macOS
BaiduPCS-Go mount /mnt/baidupan

# 挂载指定网盘目录
BaiduPCS-Go mount --path /我的资源 X: