### PR TITLE
fix(transfer): 修复新格式分享转存误报 STOKEN (#534)

### DIFF
--- a/baidupcs/transfer.go
+++ b/baidupcs/transfer.go
@@ -120,7 +120,7 @@ func (pcs *BaiduPCS) AccessSharePage(featurestr string, first bool) (tokens map[
 	tokens = make(map[string]string)
 	tokens["ErrMsg"] = "0"
 	headers := make(map[string]string)
-	headers["User-Agent"] = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.100 Safari/537.36"
+	headers["User-Agent"] = NetdiskUA // 修 #534：Chrome 76 UA 被百度反爬弹到无 loginstate 的登录页；netdisk 客户端 UA 放行拿真实分享页
 	headers["Referer"] = "https://pan.baidu.com/disk/home"
 	if !first {
 		headers["Referer"] = fmt.Sprintf("https://pan.baidu.com/share/init?surl=%s", featurestr[1:])
@@ -145,7 +145,7 @@ func (pcs *BaiduPCS) AccessSharePage(featurestr string, first bool) (tokens map[
 		tokens["ErrMsg"] = "分享链接已失效"
 		return
 	} else {
-		re, _ := regexp.Compile(`(\{.+?loginstate.+?\})\);`)
+		re, _ := regexp.Compile(`(\{.+?loginstate.+?\})`) // 修 #534：旧页 locals.mset({...}); 要求 )，新页 try{{...}}; 无 )，去 \)\; 终结符兼容两者
 		sub := re.FindSubmatch(body)
 		if len(sub) < 2 {
 			tokens["ErrMsg"] = "请确认登录参数中已经包含了网盘STOKEN"


### PR DESCRIPTION
## 修复 #534

fixes #534

## 根因（实测定位，非 surl 格式问题）

issue #534 把症状归到「新格式 surl（base62→base64url）」，实测**误判**：旧格式 surl 同样失败。真因是 `AccessSharePage` 两处叠加，**单独任一修复都不够**：

### 1. `baidupcs/transfer.go:123` 硬编码 Chrome 76 浏览器 UA

百度反爬对 `/s/{surl}` 分享 HTML 页端点拒绝浏览器 UA，302 弹到不含 `loginstate` 块的登录页 → 正则失配 → 兜底报「请确认登录参数中已经包含了网盘STOKEN」。

实测（容器内跑 BaiduPCS-Go，dump `AccessSharePage` 抓到的 body）：

| UA | body | 含 loginstate |
|---|---|---|
| Chrome 76（原硬编码） | 10751 字节登录页 | ❌ false |
| `NetdiskUA`（本 PR） | 5937 字节真实分享页 | ✅ true |

### 2. `baidupcs/transfer.go:148` 正则要求 `});` 终结符

旧正则 `(\{.+?loginstate.+?\})\);` 依赖旧页 `locals.mset({...});` 结构里的 `})`。netdisk UA 拿到的真实分享页把 loginstate JSON 包在 `try{ {...} }catch(ex){...}` 里，对象结尾是 `};`（**无 `)`**），正则不匹配。

```js
// 旧页结构（正则能匹配）
locals.mset({"bdstoken":"...","loginstate":1,...});

// 新页结构（正则失配，无 )）
try { {"username":"...","bdstoken":"...","loginstate":1,...}; } catch(ex){...}
```

去掉 `\)\;` 终结符 → `(\{.+?loginstate.+?\})` 兼容两种结构，且对旧页向后兼容（只是不再要求 `)` 包裹）。

## 修复

两行：

```diff
-	headers["User-Agent"] = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.100 Safari/537.36"
+	headers["User-Agent"] = NetdiskUA
...
-	re, _ := regexp.Compile(`(\{.+?loginstate.+?\})\);`)
+	re, _ := regexp.Compile(`(\{.+?loginstate.+?\})`)
```

## 实测验证

容器内替换二进制后跑（账号已登录、STOKEN 有效）：

```
$ BaiduPCS-Go transfer "https://pan.baidu.com/s/1sjaPJJvG00g3B_aaU-zw6w?pwd=xxxx"
分享链接转存到网盘成功, 保存了 Capture_One_Ent_16.7.4.24_mac.part1.rar 等多个文件/文件夹到当前目录
```

含 `_` / `-` 的新格式 surl 转存成功，不再误报 STOKEN。

## 为什么不单改一处

- 只改 UA（line 123）、不改正则：netdisk UA 拿到的页面是 `try{...}catch` 结构，旧正则仍因缺 `});` 失配 → 仍报 STOKEN。
- 只改正则（line 148）、不改 UA：Chrome 76 UA 被弹到无 `loginstate` 的登录页，正则无 `loginstate` 可匹配 → 仍报 STOKEN。

两处同改才通。
