### PR TITLE
fix: remove quotes from cookie values to prevent invalid byte error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/CODEBUDDY.md

--- a/requester/util.go
+++ b/requester/util.go
@@ -20,6 +20,7 @@ func ParseCookieStr(cookieStr string) []*http.Cookie {
 
 		s2[0] = strings.TrimSpace(s2[0])
 		s2[1] = strings.TrimSpace(s2[1])
+		s2[1] = strings.Trim(s2[1], "\"") // 去掉百度部分 cookie 值两侧的双引号 (如 RT), 避免 net/http 发送时报 invalid byte '"'
 
 		cookies = append(cookies, &http.Cookie{
 			Name:  s2[0],

--- a/requester/util_test.go
+++ b/requester/util_test.go
@@ -1,0 +1,40 @@
+package requester
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestParseCookieStrStripQuotes 验证百度部分 cookie 值两侧的双引号 (如 RT) 会被去除,
+// 避免 net/http 在发送 Cookie 时报 "invalid byte '"' in Cookie.Value".
+func TestParseCookieStrStripQuotes(t *testing.T) {
+	cookieStr := `BAIDUID=767874F83F19B61EA4AE1AB875BD9994:FG=1; BDUSS=mhrNmU3ZTFu; STOKEN=e334e904; RT="z=1&dm=baidu.com&si=8da0aa22&hd=1xlf"; csrfToken=5lb_cUD5`
+
+	cookies := ParseCookieStr(cookieStr)
+
+	var rtValue string
+	found := false
+	for _, c := range cookies {
+		if c.Name == "RT" {
+			rtValue = c.Value
+			found = true
+		}
+	}
+
+	if !found {
+		t.Fatal("RT cookie 未解析出来")
+	}
+	if strings.Contains(rtValue, "\"") {
+		t.Fatalf("RT 值仍包含双引号: %q", rtValue)
+	}
+	if rtValue != "z=1&dm=baidu.com&si=8da0aa22&hd=1xlf" {
+		t.Fatalf("RT 值解析错误: %q", rtValue)
+	}
+
+	// 普通无引号 cookie 应原样保留
+	for _, c := range cookies {
+		if c.Name == "BDUSS" && c.Value != "mhrNmU3ZTFu" {
+			t.Fatalf("BDUSS 值错误: %q", c.Value)
+		}
+	}
+}


### PR DESCRIPTION
# 日志
```
2026/08/05 17:57:44 net/http: invalid byte '"' in Cookie.Value; dropping invalid bytes 
  [1] ? 1.52GB/3.72GB 9.59MB/s in 5m4s, left 3m55s ............2026/08/05 17:57:45 
  net/http: invalid byte '"' in Cookie.Value; dropping invalid bytes 
  2026/08/05 17:57:45 net/http: invalid byte '"' in Cookie.Value; dropping invalid bytes 
  2026/08/05 17:57:45 net/http: invalid byte '"' in Cookie.Value; dropping invalid bytes 
  [1] ? 1.53GB/3.72GB 10.10MB/s in 5m5s, left 3m42s ............2026/08/05 17:57:46 
  net/http: invalid byte '"' in Cookie.Value; dropping invalid bytes 
  2026/08/05 17:57:46 net/http: invalid byte '"' in Cookie.Value; dropping invalid bytes 
  [1] ? 1.54GB/3.72GB 8.08MB/s in 5m6s, left 4m36s ............2026/08/05 17:57:47 
  net/http: invalid byte '"' in Cookie.Value; dropping invalid bytes 
  2026/08/05 17:57:47 net/http: invalid byte '"' in Cookie.Value; dropping invalid bytes 
  [1] ? 1.55GB/3.72GB 8.08MB/s in 5m7s, left 4m35s ............2026/08/05 17:57:48 
  net/http: invalid byte '"' in Cookie.Value; dropping invalid bytes 
  2026/08/05 17:57:48 net/http: invalid byte '"' in Cookie.Value; dropping invalid bytes 
  [1] ? 1.56GB/3.72GB 8.09MB/s in 5m8s, left 4m34s ............2026/08/05 17:57:48 
  net/http: invalid byte '"' in Cookie.Value; dropping invalid bytes 
```
# 原因
  - 根据 RFC 6265，Cookie 的 Value 里不能包含双引号 "（以及空格、;、逗号等字符）。
  - 你下载时，程序用 cookiejar 给每个下载请求自动带上 Cookie（internal/pcsfunctions/pcsdownload/utils.go:69 的CloneJarWithDomain，把 PCS 的 Cookie  克隆到下载服务器域名下）。
  - 每次发请求时，Go 在拼 Cookie: 请求头会调用 sanitizeCookieValue，发现某个 Cookie 的值里有"，就会丢弃掉那个非法字节并打这条警告。
  - 因为下载是分片并行、每秒发很多请求，所以这条警告就刷屏了。

# 代码改动影响
基本无害：标准库只是丢掉那个非法字节，不会丢掉整个  Cookie，所以下载仍在正常推进（日志里速度、进度都还在走）。只有当那个带 " 的 Cookie 恰好是关键鉴权 Cookie、且被丢弃的字节破坏了它的有效值时，才可能导致请求被踢登录或 401。你目前没断流，说明它不影响下载。

已重新编译并真实下载百度网盘文件验证通过