### PR TITLE
fix: handle Baidu API error code -9 (file not exist) in upload

### DIFF
--- a/internal/pcsfunctions/pcsupload/upload_task_unit.go
+++ b/internal/pcsfunctions/pcsupload/upload_task_unit.go
@@ -150,7 +150,7 @@ func (utu *UploadTaskUnit) rapidUpload() (isContinue bool, result *taskframework
 		switch pcsError.GetErrType() {
 		case pcserror.ErrTypeRemoteError:
 			switch pcsError.GetRemoteErrCode() {
-			case 31066:
+			case 31066, -9:
 			// file does not exist
 			// 不缓存文件夹
 			default:


### PR DESCRIPTION
The upload function only handled error code 31066 for 'file not exist', but Baidu API also returns error code -9 for the same condition. This caused uploads to fail when checking target directories.

Added -9 to the error handling switch case to properly handle both codes.

Fixes issue where large file uploads fail with 'param error' message.