### PR TITLE
fix: 跳过断开的软链接, 避免 WalkDir 空指针崩溃

### DIFF
--- a/pcsutil/file.go
+++ b/pcsutil/file.go
@@ -97,7 +97,10 @@ func WalkDir(dirPth, suffix string) (files []string, err error) {
 			return nil
 		}
 		if fileInfo.Mode()&os.ModeSymlink != 0 { // 读取 symbol link
-			targetFileInfo, _ := os.Stat(filename)
+			targetFileInfo, statErr := os.Stat(filename)
+			if statErr != nil { // 断开的软链接, 跳过
+				return nil
+			}
 			if targetFileInfo.IsDir() {
 				err = filepath.WalkDir(filename+string(os.PathSeparator), walkFunc)
 				return err


### PR DESCRIPTION
## 问题

`pcsutil.WalkDir` 在处理软链接时忽略了 `os.Stat` 的错误：

```go
targetFileInfo, _ := os.Stat(filename)
if targetFileInfo.IsDir() {
```

当软链接指向的目标不存在（断开的软链接）时，`os.Stat` 返回 `nil` 的 `FileInfo`，紧接着的 `targetFileInfo.IsDir()` 会触发空指针解引用，导致整个程序 panic。

## 复现

```bash
mkdir -p /tmp/t && ln -s /nonexistent /tmp/t/broken
# 在 BaiduPCS-Go 中上传 /tmp/t 目录 -> panic: runtime error: invalid memory address or nil pointer dereference
```

任何包含断开软链接的目录（常见于 node_modules、Homebrew Cellar、构建产物目录）都会命中。

## 修复

检查 `os.Stat` 的错误，跳过断开的软链接：

```go
targetFileInfo, statErr := os.Stat(filename)
if statErr != nil { // 断开的软链接, 跳过
    return nil
}
```

跳过而非报错，与 `WalkDir` 中其他非致命情况的处理方式一致——一个坏掉的软链接不应该中断整个目录遍历。

`go build ./...` 通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)